### PR TITLE
jQuery.migrateWarningsTrace property to enable console traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ This plugin adds three properties to the `jQuery` object that can be used progra
 
 `jQuery.migrateMute`: Set this property to `true` to prevent console warnings from being generated in the debugging version. The `jQuery.migrateWarnings` array is still maintained when this property is set, which allows programmatic inspection without console output.
 
+`jQuery.migrateWarningsTrace`: Set this property to `true` to enable console traces.
+
 `jQuery.migrateReset()`: This method clears the `jQuery.migrateWarnings` array and "forgets" the list of messages that have been seen already.
 
 ## Reporting problems

--- a/src/migrate.js
+++ b/src/migrate.js
@@ -7,6 +7,9 @@ jQuery.migrateWarnings = [];
 // Set to true to prevent console output; migrateWarnings still maintained
 // jQuery.migrateMute = false;
 
+// Set to true to enable warnings traces
+// jQuery.migrateWarningsTrace = false;
+
 // Forget any warnings we've already given; public
 jQuery.migrateReset = function() {
 	warnedAbout = {};
@@ -19,6 +22,7 @@ function migrateWarn( msg) {
 		jQuery.migrateWarnings.push( msg );
 		if ( window.console && console.warn && !jQuery.migrateMute ) {
 			console.warn( "JQMIGRATE: " + msg );
+			jQuery.migrateWarningsTrace && console.trace && console.trace();
 		}
 	}
 }


### PR DESCRIPTION
It is very hard to find deprecated jQuery calls only by warnings.

`console.trace()` is great to find what was called and where.
