### PR TITLE
Fix #51: New init method for subclasses

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -96,11 +96,10 @@ jQuery.sub = function() {
 	jQuerySub.fn.constructor = jQuerySub;
 	jQuerySub.sub = this.sub;
 	jQuerySub.fn.init = function init( selector, context ) {
-		if ( context && context instanceof jQuery && !(context instanceof jQuerySub) ) {
-			context = jQuerySub( context );
-		}
-
-		return jQuery.fn.init.call( this, selector, context, rootjQuerySub );
+		var instance = jQuery.fn.init.call( this, selector, context, rootjQuerySub );
+		return instance instanceof jQuerySub ?
+			instance :
+			jQuerySub( instance );
 	};
 	jQuerySub.fn.init.prototype = jQuerySub.fn;
 	var rootjQuerySub = jQuerySub(document);

--- a/test/core.js
+++ b/test/core.js
@@ -193,27 +193,11 @@ test( "jQuery.sub() - .fn Methods", function(){
 	expect( 378 );
 
 	var Subclass = jQuery.sub(),
-		SubclassSubclass = Subclass.sub(),
-		jQueryDocument = jQuery(document),
-		selectors, contexts, method, arg, description;
-
-	jQueryDocument.toString = function(){ return "jQueryDocument"; };
-
-	Subclass.fn.subclassMethod = function(){};
-	SubclassSubclass.fn.subclassSubclassMethod = function(){};
-
-	selectors = [
-		"body",
-		"html, body",
-		"<div></div>"
-	];
-
-	contexts = [undefined, document, jQueryDocument];
-
-	jQuery.expandedEach = jQuery.each;
-	jQuery.each(selectors, function(i, selector){
-
-		jQuery.expandedEach({ // all methods that return a new jQuery instance
+		SubSubclass = Subclass.sub(),
+		jQueryDocument = jQuery( document ),
+		contexts = [ undefined, document, jQueryDocument ],
+		selectors = [ "body", "html,body", "<div></div>" ],
+		methodArguments = {
 			"eq": 1 ,
 			"add": document,
 			"end": undefined,
@@ -221,36 +205,41 @@ test( "jQuery.sub() - .fn Methods", function(){
 			"closest": "div",
 			"filter": document,
 			"find": "div"
-		}, function(method, arg){
-			jQuery.each(contexts, function(i, context){
+		};
 
-				description = "(\""+selector+"\", "+context+")."+method+"("+(arg||"")+")";
+	jQueryDocument.toString = function() {
+		return "jQueryDocument";
+	};
 
-				deepEqual(
-					(function(var_args){ return jQuery.fn[method].apply(jQuery(selector, context), arguments).subclassMethod; })(arg),
-					undefined, "jQuery"+description+" doesn't have Subclass methods"
-				);
-				deepEqual(
-					(function(var_args){ return jQuery.fn[method].apply(jQuery(selector, context), arguments).subclassSubclassMethod; })(arg),
-					undefined, "jQuery"+description+" doesn't have SubclassSubclass methods"
-				);
-				deepEqual(
-					Subclass(selector, context)[method](arg).subclassMethod, Subclass.fn.subclassMethod,
-					"Subclass"+description+" has Subclass methods"
-				);
-				deepEqual(
-					Subclass(selector, context)[method](arg).subclassSubclassMethod, undefined,
-					"Subclass"+description+" doesn't have SubclassSubclass methods"
-				);
-				deepEqual(
-					SubclassSubclass(selector, context)[method](arg).subclassMethod, Subclass.fn.subclassMethod,
-					"SubclassSubclass"+description+" has Subclass methods"
-				);
-				deepEqual(
-					SubclassSubclass(selector, context)[method](arg).subclassSubclassMethod, SubclassSubclass.fn.subclassSubclassMethod,
-					"SubclassSubclass"+description+" has SubclassSubclass methods"
-				);
+	Subclass.fn.subMethod = function(){};
+	SubSubclass.fn.subSubMethod = function(){};
 
+	jQuery.each( contexts, function( i, context ) {
+			jQuery.each( selectors, function( i, selector ) {
+				jQuery.each( methodArguments, function( method, arg ){
+
+				var description = "(\"" + selector + "\", " + context + ")." + method + "(" + (arg || "") + ")",
+					$instance = jQuery( selector, context )[ method ]( arg ),
+					$subInstance = Subclass( selector, context )[ method ]( arg ),
+					$subSubInstance = SubSubclass( selector, context )[ method ]( arg );
+
+				// jQuery
+				strictEqual( $instance.subMethod, undefined,
+					"jQuery" + description + " doesn't have Subclass methods" );
+				strictEqual( $instance.subSubMethod, undefined,
+					"jQuery" + description + " doesn't have SubSubclass methods" );
+
+				// Subclass
+				strictEqual( $subInstance.subMethod, Subclass.fn.subMethod,
+					"Subclass" + description + " has Subclass methods" );
+				strictEqual( $subInstance.subSubMethod, undefined,
+					"Subclass" + description + " doesn't have SubSubclass methods" );
+
+				// SubSubclass
+				strictEqual( $subSubInstance.subMethod, Subclass.fn.subMethod,
+					"SubSubclass" + description + " has Subclass methods" );
+				strictEqual( $subSubInstance.subSubMethod, SubSubclass.fn.subSubMethod,
+					"SubSubclass" + description + " has SubSubclass methods" );
 			});
 		});
 	});


### PR DESCRIPTION
cc @dmethvin

This is necessary because https://github.com/jquery/jquery/commit/2f627494f28c08e5bba3c32d6c9d9167503322fc#diff-7eb52b366866677666470e019283c8eaL35 stopped passing an instance of `jQuery( document )` to `jQuery.fn.init`.
