### PR TITLE
Fix error when jQuery is trying to do toLowerCase an empty array.

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -14,6 +14,13 @@ var attrFn = jQuery( "<input/>", { size: 1 } ).attr("size") && jQuery.attrFn,
 migrateWarnProp( jQuery, "attrFn", attrFn || {}, "jQuery.attrFn is deprecated" );
 
 jQuery.attr = function( elem, name, value, pass ) {
+
+	// Some plugins try to set an Array of properties,
+	// Then this Array is set like an empty Array and occurs an error.
+	if ( Array.isArray( name ) ) {
+		return;
+	}
+
 	var lowerName = name.toLowerCase(),
 		nType = elem && elem.nodeType;
 


### PR DESCRIPTION
I updated the version of jQuery of an old app. This app have a plugin called jqGrid, and in the method "setCell" is possible pass an Array of properties (attributes) for set them in a cell. The code have a lot of this and the guy who implemented it time ago the code have a lot of empty arrays set. So when jquery-migrate try to do a toLowerCase() of an empty array it throws an error. I don't know if is the best fix but works for me.
