### PR TITLE
Build: remove dates from copyright notice

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,4 @@
-Copyright 2012, 2014 jQuery Foundation and other contributors,
-https://jquery.org/
+Copyright jQuery Foundation and other contributors, https://jquery.org/
 
 This software consists of voluntary contributions made by many
 individuals. For exact contribution history, see the revision history


### PR DESCRIPTION
This should have been done in https://github.com/jquery/jquery-migrate/commit/153233281c3ed4256413208e04c091aa1ab36313, but seems like it isn't.