### PR TITLE
Event: .load() and .unload() are deprecated as of 1.8

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -38,17 +38,25 @@ jQuery.event.remove = function( elem, types, handler, selector, mappedTypes ){
 	eventRemove.call( this, elem, hoverHack( types ) || "", handler, selector, mappedTypes );
 };
 
-jQuery.fn.error = function() {
-	var args = Array.prototype.slice.call( arguments, 0);
-	migrateWarn("jQuery.fn.error() is deprecated");
-	args.splice( 0, 0, "error" );
-	if ( arguments.length ) {
-		return this.bind.apply( this, args );
-	}
-	// error event should not bubble to window, although it does pre-1.7
-	this.triggerHandler.apply( this, args );
-	return this;
-};
+jQuery.each( [ "load", "unload", "error" ], function( _, name ) {
+
+	jQuery.fn[ name ] = function() {
+		var args = Array.prototype.slice.call( arguments, 0 );
+		migrateWarn( "jQuery.fn." + name + "() is deprecated" );
+		args.splice( 0, 0, name );
+		if ( arguments.length ) {
+			return this.bind.apply( this, args );
+		}
+
+		// Use .triggerHandler here because:
+		// - load and unload events don't need to bubble, only applied to window
+		// - error event should not bubble to window, although it does pre-1.7
+		// See http://bugs.jquery.com/ticket/11820
+		this.triggerHandler.apply( this, args );
+		return this;
+	};
+
+});
 
 jQuery.fn.toggle = function( fn, fn2 ) {
 

--- a/test/event.js
+++ b/test/event.js
@@ -722,13 +722,39 @@ test( "error() event method", function() {
 	expect( 2 );
 
 	expectWarning( "jQuery.fn.error()", function() {
-		jQuery("<img />")
+		jQuery( "<img />" )
 			.error(function(){
 				ok( true, "Triggered error event" );
 			})
 			.error()
-			.unbind("error")
+			.unbind( "error" )
 			.error()
+			.remove();
+	});
+});
+
+test( "load() and unload() event methods", function() {
+	expect( 4 );
+
+	expectWarning( "jQuery.fn.load()", function() {
+		jQuery( "<img />" )
+			.load(function(){
+				ok( true, "Triggered load event" );
+			})
+			.load()
+			.unbind( "load" )
+			.load()
+			.remove();
+	});
+
+	expectWarning( "jQuery.fn.unload()", function() {
+		jQuery( "<img />" )
+			.unload(function(){
+				ok( true, "Triggered unload event" );
+			})
+			.unload()
+			.unbind( "unload" )
+			.unload()
 			.remove();
 	});
 });

--- a/warnings.md
+++ b/warnings.md
@@ -93,6 +93,13 @@ $.ajax({
 
 **Solution:** Change any use of `$().error(fn)` to `$().on("error", fn)`.
 
+### JQMIGRATE: jQuery.fn.load() is deprecated
+### JQMIGRATE: jQuery.fn.unload() is deprecated
+
+**Cause:** The `$().load()` and `$().unload()` methods attach an "load" and "unload" event, respectively, to an element. They were deprecated in 1.9 to reduce confusion with the AJAX-related `$.load()` method that loads HTML fragments and which has not been deprecated. Note that these two methods are used almost exclusively with a jQuery collection consisting of only the `window` element. Also note that attaching an "unload" or "beforeunload" event on a window via any means can impact performance on some browsers because it disables the document cache (bfcache). For that reason we strongly advise against it.
+
+**Solution:** Change any use of `$().load(fn)` to `$().on("load", fn)` and `$().unload(fn)` to `$().on("unload", fn)`.
+
 ### JQMIGRATE: jQuery.fn.toggle(handler, handler...) is deprecated
 
 **Cause:** There are two completely different meanings for the `.toggle()` method. The use of `.toggle()` to show or hide elements is _not_ affected. The use of `.toggle()` as a specialized click handler was deprecated in 1.8 and removed in 1.9. 

--- a/warnings.md
+++ b/warnings.md
@@ -96,7 +96,7 @@ $.ajax({
 ### JQMIGRATE: jQuery.fn.load() is deprecated
 ### JQMIGRATE: jQuery.fn.unload() is deprecated
 
-**Cause:** The `$().load()` and `$().unload()` methods attach an "load" and "unload" event, respectively, to an element. They were deprecated in 1.9 to reduce confusion with the AJAX-related `$.load()` method that loads HTML fragments and which has not been deprecated. Note that these two methods are used almost exclusively with a jQuery collection consisting of only the `window` element. Also note that attaching an "unload" or "beforeunload" event on a window via any means can impact performance on some browsers because it disables the document cache (bfcache). For that reason we strongly advise against it.
+**Cause:** The `.load()` and `.unload()` event methods attach a "load" and "unload" event, respectively, to an element. They were deprecated in 1.9 to reduce confusion with the AJAX-related `.load()` method that loads HTML fragments and which has not been deprecated. Note that these two methods are used almost exclusively with a jQuery collection consisting of only the `window` element. Also note that attaching an "unload" or "beforeunload" event on a window via any means can impact performance on some browsers because it disables the document cache (bfcache). For that reason we strongly advise against it.
 
 **Solution:** Change any use of `$().load(fn)` to `$().on("load", fn)` and `$().unload(fn)` to `$().on("unload", fn)`.
 


### PR DESCRIPTION
Refactored the code to handle .error() since the three have the same form.

Ref #89