### PR TITLE
Prepare for npm publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+.project
+.settings
+*~
+*.diff
+*.patch
+/*.html
+.DS_Store
+node_modules

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "jquery-migrate",
   "title": "jQuery Migrate",
   "description": "Migrate older jQuery code to jQuery 1.9+",
+  "main": "dist/jquery-migrate.js",
   "version": "1.2.2-pre",
   "homepage": "https://github.com/jquery/jquery-migrate",
   "author": {
@@ -21,10 +22,8 @@
       "url": "https://github.com/jquery/jquery-migrate/blob/master/LICENSE.txt"
     }
   ],
-  "dependencies": {
-    "jquery": "^2.1.3"
-  },
   "devDependencies": {
+    "jquery": "^2.1.3",
     "grunt-git-authors": "3.0.0",
     "grunt-contrib-concat": "0.5.1",
     "grunt-contrib-watch": "0.6.1",
@@ -35,6 +34,9 @@
     "grunt": "~0.4.5",
     "qunitjs": "1.17.1",
     "testswarm": "~1.1.0"
+  },
+  "scripts": {
+    "prepublish": "grunt"
   },
   "keywords": []
 }


### PR DESCRIPTION
This:

* Adds a `main` field to the `package.json` pointing to the generated dist copy of jquery-migrate.
* Adds an `npm prepublish` step to run grunt before publishing to npm.
* Moves the jquery dependency to `devDependencies`. jQuery is never directly `require`d by the code, and is implicitly assumed to exist (see [backbone's package.json discussion](https://github.com/jashkenas/backbone/issues/2997#issuecomment-35131774) for more info)

This is deliberately unopinionated about CommonJS. I'd like to solve that issue in a separate pull request, but at least now jquery-migrate can be used with npm and either a script tag or a `jQuery` in the global scope. I'd like to implement something similar to [jQuery's wrapper](https://github.com/jquery/jquery/blob/master/src/intro.js), but we should decide what the API should look like. For example, it could remain the same (ie `require('jquery-migrate')`) and bring jquery in as a formal dependency and patch that, but npm's file tree is not flat for the time being (this is going to change in 3.x), and we might end up patching a different jQuery than the user was expecting.

An alternate API would be to use `require('jquery-migrate')(jQuery)`, passing in a reference to the desired jQuery to patch into a factory function. This would clear up the above issue but makes CommonJS somewhat more of a special case. Then there's the handling of a lack of a `window` object that jQuery handles, and there's a question of whether we should handle that too.

I imagine jQuery plugins face these same issues, so I'd love to hear if you have any experience or thoughts on this.

Thanks!