### PR TITLE
CSS: Add jQuery.swap and warnings

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,6 +22,7 @@ module.exports = function(grunt) {
 			"src/migrate.js",
 			"src/attributes.js",
 			"src/core.js",
+			"src/css.js",
 			"src/ajax.js",
 			"src/data.js",
 			"src/manipulation.js",

--- a/src/css.js
+++ b/src/css.js
@@ -1,0 +1,41 @@
+
+var internalSwapCall = false;
+
+// If this version of jQuery has .swap(), don't false-alarm on internal uses
+if ( jQuery.swap ) {
+	jQuery.each( [ "height", "width", "reliableMarginRight" ], function( _, name ) {
+		var oldHook = jQuery.cssHooks[ name ] && jQuery.cssHooks[ name ].get;
+
+		if ( oldHook ) {
+			jQuery.cssHooks[ name ].get = function() {
+				internalSwapCall = true;
+				oldHook.apply( this, arguments );
+				internalSwapCall = false;
+			};
+		}
+	});
+}
+
+jQuery.swap = function( elem, options, callback, args ) {
+	var ret, name,
+		old = {};
+
+	if ( !internalSwapCall ) {
+		migrateWarn( "jQuery.swap() is undocumented and deprecated" );
+	}
+
+	// Remember the old values, and insert the new ones
+	for ( name in options ) {
+		old[ name ] = elem.style[ name ];
+		elem.style[ name ] = options[ name ];
+	}
+
+	ret = callback.apply( elem, args || [] );
+
+	// Revert the old values
+	for ( name in options ) {
+		elem.style[ name ] = old[ name ];
+	}
+
+	return ret;
+};

--- a/test/css.js
+++ b/test/css.js
@@ -1,0 +1,25 @@
+
+module("css");
+
+test( "jQuery.swap()", function( assert ) {
+	assert.expect( 6 );
+
+	var div = document.createElement( "div" );
+	div.style.borderWidth = "4px";
+
+	expectWarning( "External swap() call", function() {
+		jQuery.swap( div, { borderWidth: "5px" }, function( arg ) {
+
+			assert.equal( this.style.borderWidth, "5px", "style was changed" );
+			assert.equal( arg, 42, "arg was passed" );
+
+		}, [ 42 ] );
+	});
+	assert.equal( div.style.borderWidth, "4px", "style was restored" );
+
+	expectNoWarning( "Internal swap() call", function() {
+		var $fp = jQuery( "#firstp" ).css( "width", "9px" ).hide();
+		assert.equal( $fp.hide().width(), 9, "correct width" );
+	});
+
+});

--- a/test/index.html
+++ b/test/index.html
@@ -34,6 +34,7 @@
 	<!-- Unit test files -->
 	<script src="migrate.js"></script>
 	<script src="core.js"></script>
+	<script src="css.js"></script>
 	<script src="data.js"></script>
 	<script src="attributes.js"></script>
 	<script src="manipulation.js"></script>

--- a/warnings.md
+++ b/warnings.md
@@ -178,3 +178,8 @@ $(document).ajaxStart(function(){ $("#status").text("Ajax started"); });
 
 **Solution**: Replace any use of `.size()` with `.length`.
 
+### JQMIGRATE: jQuery.swap() is undocumented and deprecated
+
+**Cause**: The `jQuery.swap()` method temporarily exchanges a set of CSS properties. It was never documented as part of jQuery's public API and should not be used because it can cause performance problems due to forced layout.
+
+**Solution**: Rework the code to avoid calling `jQuery.swap()`, or explicitly set and restore the properties you need to change.


### PR DESCRIPTION
Fixes #100. 

I had to do some unusual things here to monitor the internal calls and not yell about them. Any better ideas on how to do that? AFAICT only these three hooks have been used back to jQuery 1.6.4 which is all Migrate supports.