### PR TITLE
Support for IE11

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -79,9 +79,10 @@ jQuery.uaMatch = function( ua ) {
 		/(webkit)[ \/]([\w.]+)/.exec( ua ) ||
 		/(opera)(?:.*version|)[ \/]([\w.]+)/.exec( ua ) ||
 		/(msie) ([\w.]+)/.exec( ua ) ||
+		/(trident)\/([\w.]+)/.exec( ua ) ||
 		ua.indexOf("compatible") < 0 && /(mozilla)(?:.*? rv:([\w.]+)|)/.exec( ua ) ||
 		[];
-
+		
 	return {
 		browser: match[ 1 ] || "",
 		version: match[ 2 ] || "0"
@@ -103,6 +104,8 @@ if ( !jQuery.browser ) {
 		browser.webkit = true;
 	} else if ( browser.webkit ) {
 		browser.safari = true;
+	} else if ( browser.trident ) {
+		browser.msie = true;
 	}
 
 	jQuery.browser = browser;


### PR DESCRIPTION
From IE11, user agent doesn't have msie keyword.
This commit is for 'Trident' engine to be identified as IE.