### PR TITLE
Core: Warn about attribute selectors that have an unquoted hash

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -3,6 +3,7 @@ var matched, browser,
 	oldInit = jQuery.fn.init,
 	oldParseJSON = jQuery.parseJSON,
 	rspaceAngle = /^\s*</,
+	rattrHash = /\[\s*\w+\s*[~|^$*]?=\s*#/,
 	// Note: XSS check is done below after string is trimmed
 	rquickExpr = /^([^<]*)(<[\w\W]+>)([^>]*)$/;
 
@@ -38,10 +39,17 @@ jQuery.fn.init = function( selector, context, rootjQuery ) {
 		}
 	}
 
-	// jQuery( "#" ) is a bogus ID selector, but it returned an empty set before jQuery 3.0
 	if ( selector === "#" ) {
+
+		// jQuery( "#" ) is a bogus ID selector, but it returned an empty set before jQuery 3.0
 		migrateWarn( "jQuery( '#' ) is not a valid selector" );
 		selector = [];
+
+	} else if ( rattrHash.test( selector ) ) {
+
+		// The nonstandard and undocumented unquoted-hash was removed in jQuery 1.12.0
+		// Note that this doesn't actually fix the selector due to potential false positives
+		migrateWarn( "Attribute selectors with '#' must be quoted: '" + selector + "'" );
 	}
 
 	ret = oldInit.apply( this, arguments );

--- a/test/core.js
+++ b/test/core.js
@@ -62,6 +62,30 @@ test( "jQuery( '#' )", function() {
 	});
 });
 
+test( "attribute selectors with naked '#'", function() {
+	expect( 3 );
+
+	// These are wrapped in try/catch because they throw on jQuery 1.12.0+
+
+	expectWarning( "attribute equals", function() {
+		try {
+			jQuery( "a[href=#]" );
+		} catch( e ) {}
+	});
+
+	expectWarning( "attribute contains", function() {
+		try {
+			jQuery( "link[rel*=#stuff]" );
+		} catch( e ) {}
+	});
+
+	expectWarning( "attribute starts, with spaces", function() {
+		try {
+			jQuery( "a[href ^= #junk]" );
+		} catch( e ) {}
+	});
+});
+
 test( "selector state", function() {
 	expect( 18 );
 

--- a/warnings.md
+++ b/warnings.md
@@ -30,6 +30,12 @@ This is _not_ a warning, but a console log message the plugin shows when it firs
 
 **Solution**: Usually this warning is due to an error in the HTML string, where text is present when it should not be there. Remove the leading or trailing text before passing the string to `$.parseHTML()` if it should not be part of the collection. Alternatively you can use `$($.parseHTML(html)).filter("*")` to remove all top-level text nodes from the set and leave only elements.
 
+### JQMIGRATE: Attribute selectors with '#' must be quoted
+
+**Cause:** CSS selectors such as `a[href=#main]` are not valid CSS syntax because the value contains special characters that are not quoted. Until jQuery 1.11.3/2.1.4 this syntax was accepted, but the behavior is non-standard and was never documented. In later versions this selector throws an error. *In some rare cases Migrate may mis-diagnose this problem, so it does not attempt a repair.*
+
+**Solution**: Put quotes around any attribute values that have special characters, e.g. `a[href="#main"]`. The warning message contains the selector that caused the problem, use that to find the selector in the source files.
+
 ### JQMIGRATE: Can't change the 'type' of an input or button in IE 6/7/8
 
 **Cause:** IE 6, 7, and 8 throw an error if you attempt to change the type attribute of an input or button element, for example to change a radio button to a checkbox. Prior to 1.9, jQuery threw an error for every browser to create consistent behavior. As of jQuery 1.9 setting the type is allowed, but will still throw an error in oldIE. 


### PR DESCRIPTION
Fixes #140

Although technically a selector can be used in a lot of places in the API, all our reports in #140 are coming from a simple pattern that this does warn about. Since we don't actually fix the problem it doesn't seem that critical to be thorough with detecting it either. 