### PR TITLE
Build: Add Istanbul for code coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist
+coverage
 CDN
 .project
 .settings

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 CDN
+coverage
 .project
 .settings
 *~

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -65,6 +65,15 @@ module.exports = function(grunt) {
 			}
 		},
 		qunit: {
+			options: {
+				coverage: {
+					disposeCollector: true,
+					instrumentedFiles: "temp/",
+					src: [ "dist/jquery-migrate.js" ],
+					htmlReport: "coverage/",
+					linesThresholdPct: 85
+				}
+			},
 			files: [ "test/**/*.html" ]
 		},
 		npmcopy: {
@@ -122,7 +131,7 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks("grunt-contrib-watch");
 	grunt.loadNpmTasks("grunt-contrib-jshint");
 	grunt.loadNpmTasks("grunt-contrib-uglify");
-	grunt.loadNpmTasks("grunt-contrib-qunit");
+	grunt.loadNpmTasks("grunt-qunit-istanbul");
 	grunt.loadNpmTasks("grunt-npmcopy");
 
 	// Default task.

--- a/package.json
+++ b/package.json
@@ -27,15 +27,17 @@
     "grunt": "~0.4.5",
     "grunt-contrib-concat": "0.5.1",
     "grunt-contrib-jshint": "0.11.0",
-    "grunt-contrib-qunit": "0.5.2",
     "grunt-contrib-uglify": "0.8.0",
     "grunt-contrib-watch": "0.6.1",
     "grunt-git-authors": "3.0.0",
     "grunt-npmcopy": "0.1.0",
+    "grunt-qunit-istanbul": "0.6.0",
     "jquery": "^2.1.3",
-    "phantomjs-polyfill": "0.0.1",
     "qunitjs": "1.17.1",
     "testswarm": "~1.1.0"
+  },
+  "scripts": {
+    "prepublish": "grunt"
   },
   "keywords": []
 }


### PR DESCRIPTION
Coverage test is running against the Phantom build but it's still useful for some basic sanity checking. It will become more so once we move to supporting only a single version of jQuery and don't conditionally fill APIs.