### PR TITLE
Ajax: Warn and fill the jQXHR .success, .error, and .complete methods

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,6 +22,7 @@ module.exports = function( grunt ) {
 			"src/version.js",
 			"src/migrate.js",
 			"src/core.js",
+			"src/ajax.js",
 			"src/css.js",
 			"src/effects.js",
 			"src/event.js",

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -1,0 +1,18 @@
+
+var oldAjax = jQuery.ajax;
+
+jQuery.ajax = function( ) {
+	var jQXHR = oldAjax.apply( this, arguments );
+
+	// Be sure we got a jQXHR (e.g., not sync)
+	if ( jQXHR.promise ) {
+		migrateWarnProp( jQXHR, "success", jQXHR.done,
+			"jQXHR.success is deprecated and removed" );
+		migrateWarnProp( jQXHR, "error", jQXHR.fail,
+			"jQXHR.error is deprecated and removed" );
+		migrateWarnProp( jQXHR, "complete", jQXHR.always,
+			"jQXHR.complete is deprecated and removed" );
+	}
+
+	return jQXHR;
+};

--- a/src/migrate.js
+++ b/src/migrate.js
@@ -46,10 +46,6 @@ function migrateWarnProp( obj, prop, value, msg ) {
 		get: function() {
 			migrateWarn( msg );
 			return value;
-		},
-		set: function( newValue ) {
-			migrateWarn( msg );
-			value = newValue;
 		}
 	} );
 }

--- a/src/migrate.js
+++ b/src/migrate.js
@@ -39,6 +39,21 @@ function migrateWarn( msg ) {
 	}
 }
 
+function migrateWarnProp( obj, prop, value, msg ) {
+	Object.defineProperty( obj, prop, {
+		configurable: true,
+		enumerable: true,
+		get: function() {
+			migrateWarn( msg );
+			return value;
+		},
+		set: function( newValue ) {
+			migrateWarn( msg );
+			value = newValue;
+		}
+	} );
+}
+
 if ( document.compatMode === "BackCompat" ) {
 
 	// JQuery has never supported or tested Quirks Mode

--- a/test/ajax.js
+++ b/test/ajax.js
@@ -1,0 +1,23 @@
+module( "ajax" );
+
+test( "jQuery.ajax() deprecations on jqXHR", function( assert ) {
+	assert.expect( 3 );
+
+	var done = assert.async();
+
+	expectWarning( ".success(), .error(), .compete() calls", 3, function() {
+
+		jQuery.ajax( "/not-found.404" )
+			.success( jQuery.noop )
+			.error( function( jQXHR ) {
+
+				// Local file errors returns 0, pretend it's a 404
+				assert.equal( jQXHR.status || 404, 404, "ajax error" );
+			} )
+			.complete( function() {
+				assert.ok( true, "ajax complete" );
+				done();
+			} );
+	} );
+
+} );

--- a/test/index.html
+++ b/test/index.html
@@ -36,6 +36,7 @@
 	<!-- Unit test files -->
 	<script src="migrate.js"></script>
 	<script src="core.js"></script>
+	<script src="ajax.js"></script>
 	<script src="css.js"></script>
 	<script src="event.js"></script>
 	<script src="traversing.js"></script>

--- a/test/testinit.js
+++ b/test/testinit.js
@@ -22,6 +22,7 @@ TestManager = {
 				"version",
 				"migrate",
 				"core",
+				"ajax",
 				"css",
 				"effects",
 				"event",

--- a/warnings.md
+++ b/warnings.md
@@ -25,6 +25,14 @@ This is _not_ a warning, but a console log message the plugin shows when it firs
 
 **Solution:** Put a [valid doctype](http://www.w3.org/QA/2002/04/valid-dtd-list.html) in the document and ensure that the document is rendering in standards mode. The simplest valid doctype is the HTML5 one, which we highly recommend: `<!doctype html>` . The jQuery Migrate plugin does not attempt to fix issues related to quirks mode.
 
+### JQMIGRATE: jQXHR.success is deprecated and removed
+### JQMIGRATE: jQXHR.error is deprecated and removed
+### JQMIGRATE: jQXHR.complete is deprecated and removed
+
+**Cause:** The `.success()`, `.error()`, and `.complete()` methods of the `jQXHR` object returned from `jQuery.ajax()` have been deprecated since jQuery 1.8 and were removed in jQuery 3.0.
+
+**Solution:** Replace the use of these methods with the standard Deferred methods: `.success()` becomes `.done()`, `.error()` becomes `.fail()`, and `.complete()` becomes `.always()`.
+
 ### JQMIGRATE: jQuery.fn.error() is deprecated
 
 **Cause:** The `$().error()` method was used to attach an "error" event to an element but has been removed in 1.9 to reduce confusion with the `$.error()` method which is unrelated and has not been deprecated. It also serves to discourage the temptation to use `$(window).error()` which does not work because `window.onerror` does not follow standard event handler conventions. The `$().error()` method was removed in jQuery 3.0.


### PR DESCRIPTION
Fixes #88 

This reintroduces a streamlined `migrateWarnProp` since we don't need to support a missing broken `Object.defineProperty` like IE8. That also means it will issue the warning on property access rather than wait until the method call, but that won't matter in most cases. In the cases where it does matter, you probably want to know where the property was accessed.