### PR TITLE
Core: Warn and fill jQuery.expr.filters and [":"]

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -32,3 +32,9 @@ jQuery.parseJSON = function() {
 	migrateWarn( "jQuery.parseJSON is deprecated; use JSON.parse" );
 	return JSON.parse.apply( null, arguments );
 };
+
+// Now jQuery.expr.pseudos is the standard incantation
+migrateWarnProp( jQuery.expr, "filters", jQuery.expr.pseudos,
+	"jQuery.expr.filters is now jQuery.expr.pseudos" );
+migrateWarnProp( jQuery.expr, ":", jQuery.expr.pseudos,
+	"jQuery.expr[\":\"] is now jQuery.expr.pseudos" );

--- a/test/core.js
+++ b/test/core.js
@@ -155,3 +155,32 @@ test( "jQuery.parseJSON", function() {
 		);
     } );
 } );
+
+test( "jQuery.expr.pseudos aliases", function( assert ) {
+	assert.expect( 7 );
+
+	expectWarning( "jQuery.expr.filters", function() {
+		jQuery.expr.filters.mazda = function( elem ) {
+			return elem.style.zoom === "3";
+		};
+	} );
+
+	expectWarning( "jQuery.expr[':']", function() {
+		jQuery.expr[ ":" ].marginal = function( elem ) {
+			return parseInt( elem.style.marginLeftWidth ) > 20;
+		};
+	} );
+
+	expectNoWarning( "jQuery.expr.pseudos", function() {
+		var fixture = jQuery( "#qunit-fixture" ).prepend( "<p>hello</p>" );
+
+		assert.ok( jQuery.expr.pseudos.mazda, "filters assigned" );
+		assert.ok( jQuery.expr.pseudos.marginal, "[':'] assigned" );
+		fixture.find( "p" ).first().css( "marginLeftWidth", "40px" );
+		assert.equal( fixture.find( "p:marginal" ).length, 1, "One marginal element" );
+		assert.equal( fixture.find( "div:mazda" ).length, 0, "No mazda elements" );
+		delete jQuery.expr.pseudos.mazda;
+		delete jQuery.expr.pseudos.marginal;
+	} );
+
+} );

--- a/warnings.md
+++ b/warnings.md
@@ -105,3 +105,10 @@ See jQuery-ui [commit](https://github.com/jquery/jquery-ui/commit/c0093b599fcd58
 **Cause**: The `jQuery.parseJSON` method in recent jQuery is identical to the native `JSON.parse`. As of jQuery 3.0 `jQuery.parseJSON` is deprecated.
 
 **Solution**: Replace any use of `jQuery.parseJSON` with `JSON.parse`.
+
+### JQMIGRATE: jQuery.expr[':'] is jQuery.expr.pseudos
+### JQMIGRATE: jQuery.expr.filters is now jQuery.expr.pseudos
+
+**Cause:** The standard way to add new custom selectors through jQuery is `jQuery.expr.pseudos`. These two other aliases are deprecated, although they still work as of jQuery 3.0.
+
+**Solution:** Rename any of the older usage to `jQuery.expr.pseudos`. The functionality is identical.


### PR DESCRIPTION
Fixes #146 

I dropped this in core.js, didn't seem worth creating a file for this.