### PR TITLE
Event: Warn and fill the deprecated .bind and .delegate methods

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -37,3 +37,25 @@ jQuery.event.special.ready = {
 		}
 	}
 };
+
+jQuery.fn.extend( {
+
+	bind: function( types, data, fn ) {
+		migrateWarn( "jQuery.fn.bind() is deprecated" );
+		return this.on( types, null, data, fn );
+	},
+	unbind: function( types, fn ) {
+		migrateWarn( "jQuery.fn.unbind() is deprecated" );
+		return this.off( types, null, fn );
+	},
+	delegate: function( selector, types, data, fn ) {
+		migrateWarn( "jQuery.fn.delegate() is deprecated" );
+		return this.on( types, selector, data, fn );
+	},
+	undelegate: function( selector, types, fn ) {
+		migrateWarn( "jQuery.fn.undelegate() is deprecated" );
+		return arguments.length === 1 ?
+			this.off( selector, "**" ) :
+			this.off( types, selector || "**", fn );
+	}
+} );

--- a/test/event.js
+++ b/test/event.js
@@ -52,6 +52,48 @@ test( "load() and unload() event methods", function() {
 	} );
 } );
 
+QUnit.test( ".bind() and .unbind()", function( assert ) {
+	assert.expect( 3 );
+
+	var $elem = jQuery( "<div />" ).appendTo( "#qunit-fixture" );
+
+	expectWarning( ".bind()", 1, function() {
+		$elem
+			.bind( "click", function() {
+				assert.ok( true, "click fired" );
+			} )
+			.trigger( "click" );
+	} );
+
+	expectWarning( ".unbind()", 1, function() {
+		$elem
+			.unbind( "click" )
+			.trigger( "click" );
+	} );
+} );
+
+QUnit.test( ".delegate() and .undelegate()", function( assert ) {
+	assert.expect( 3 );
+
+	var $div = jQuery( "<div />" ).appendTo( "#qunit-fixture" );
+
+	jQuery( "<p />" ).appendTo( $div );
+
+	expectWarning( ".delegate()", 1, function() {
+		$div
+			.delegate( "p", "click", function() {
+				assert.ok( true, "delegated click fired" );
+			} )
+			.find( "p" ).trigger( "click" );
+	} );
+
+	expectWarning( ".undelegate()", 1, function() {
+		$div
+			.undelegate( "p", "click" )
+			.find( "p" ).trigger( "click" );
+	} );
+} );
+
 test( "ready event", function() {
 	expect( 4 );
 

--- a/warnings.md
+++ b/warnings.md
@@ -70,6 +70,15 @@ This is _not_ a warning, but a console log message the plugin shows when it firs
 
 **Solution**: Rework the code to avoid calling `jQuery.swap()`, or explicitly set and restore the properties you need to change.
 
+### JQMIGRATE: jQuery.fn.bind() is deprecated
+### JQMIGRATE: jQuery.fn.unbind() is deprecated
+### JQMIGRATE: jQuery.fn.delegate() is deprecated
+### JQMIGRATE: jQuery.fn.undelegate() is deprecated
+
+**Cause:**: These event binding methods have been deprecated in favor of the `.on()` and `.off()` methods which can handle both delegated and direct event binding. Although the older methods are still present in jQuery 3.0, they may be removed as early as the next major-version update.
+
+**Solution**: Change the method call to use `.on()` or `.off()`, the documentation for the old methods include specific instructions. In general, the `.bind()` and `.unbind()` methods can be renamed directly to `.on()` and `.off()` respectively since the argument orders are identical.
+
 ### JQMIGRATE: 'ready' event is deprecated
 
 **Cause**: Using one of jQuery's API methods to bind a "ready" event, e.g. `$( document ).on( "ready", fn )`, will cause the function to be called when the document is ready, but only if it is attached before the browser fires its own `DOMContentLoaded` event. That makes it unreliable for many uses, particularly ones where jQuery or its plugins are loaded asynchronously after page load.


### PR DESCRIPTION
Fixes #117