### PR TITLE
Core: Warn about jQuery.isNumeric differences

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1,5 +1,6 @@
 
 var oldInit = jQuery.fn.init,
+	oldIsNumeric = jQuery.isNumeric,
 	rattrHash = /\[\s*\w+\s*[~|^$*]?=\s*(?![\s'"])[^#\]]*#/;
 
 jQuery.fn.init = function( selector ) {
@@ -31,6 +32,23 @@ jQuery.fn.size = function() {
 jQuery.parseJSON = function() {
 	migrateWarn( "jQuery.parseJSON is deprecated; use JSON.parse" );
 	return JSON.parse.apply( null, arguments );
+};
+
+jQuery.isNumeric = function( val ) {
+
+	// 2.x implementation of isNumeric
+	function isNumeric2( obj ) {
+		return !jQuery.isArray( obj ) && ( obj - parseFloat( obj ) + 1 ) >= 0;
+	}
+
+	var newValue = oldIsNumeric( val ),
+		oldValue = isNumeric2( val );
+
+	if ( newValue !== oldValue ) {
+		migrateWarn( "jQuery.isNumeric() should not be called on constructed objects" );
+	}
+
+	return oldValue;
 };
 
 migrateWarnProp( jQuery, "unique", jQuery.uniqueSort,

--- a/test/core.js
+++ b/test/core.js
@@ -156,6 +156,30 @@ test( "jQuery.parseJSON", function() {
     } );
 } );
 
+test( "jQuery.isNumeric", function( assert ) {
+    assert.expect( 8 );
+
+	var ToString = function( value ) {
+			this.toString = function() {
+				return String( value );
+			};
+		};
+
+    expectWarning( "changed cases", function() {
+		assert.equal( jQuery.isNumeric( new ToString( "42" ) ), true,
+			"Custom .toString returning number" );
+    } );
+
+    expectNoWarning( "unchanged cases", function() {
+		assert.equal( jQuery.isNumeric( 42 ), true, "number" );
+		assert.equal( jQuery.isNumeric( "42" ), true, "number string" );
+		assert.equal( jQuery.isNumeric( "devo" ), false, "non-numeric string" );
+		assert.equal( jQuery.isNumeric( [ 2, 4 ] ), false, "array" );
+		assert.equal( jQuery.isNumeric( new ToString( "devo" ) ), false,
+			"Custom .toString returning non-number" );
+	} );
+} );
+
 test( "jQuery.unique", function( assert ) {
 	assert.expect( 2 );
 

--- a/warnings.md
+++ b/warnings.md
@@ -128,6 +128,12 @@ See jQuery-ui [commit](https://github.com/jquery/jquery-ui/commit/c0093b599fcd58
 
 **Solution**: Replace any use of `jQuery.parseJSON` with `JSON.parse`.
 
+### JQMIGRATE: jQuery.isNumeric() should not be called on constructed objects
+
+**Cause**: The intended use case of `jQuery.isNumeric` is to see if its argument is either already a number, or a string that can be converted to a number. In jQuery 3.0 some edge cases changed to not return the same values. In particular, a constructed object (one created with `new MyObject()`) that contains a `.toString()` method is never considered to be numeric, even if that method returns a string that could be converted to a number. Please do not taunt this method.
+
+**Solution**: Either use a different test for being numeric, or call the object's `.toString()` method before calling the jQuery method: `jQuery.isNumeric( myObject.toString() )`.
+
 ### JQMIGRATE: jQuery.unique is deprecated; use jQuery.uniqueSort
 
 **Cause**: The fact that `jQuery.unique` sorted its results in DOM order was surprising to many who did not read the documentation carefully. As of jQuery 3.0 this function is being renamed to make it clear.


### PR DESCRIPTION
Closes #134 

It just seemed simplest to put the old implementation in the code and compare the two.

Are there any other edge cases we need to test here? Is there a better warning message?
