### PR TITLE
Core: Only check selector when it's a string

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -6,17 +6,19 @@ var oldInit = jQuery.fn.init,
 jQuery.fn.init = function( selector ) {
 	var args = Array.prototype.slice.call( arguments );
 
-	if ( selector === "#" ) {
+	if ( typeof selector === "string" ) {
+		if ( selector === "#" ) {
 
-		// JQuery( "#" ) is a bogus ID selector, but it returned an empty set before jQuery 3.0
-		migrateWarn( "jQuery( '#' ) is not a valid selector" );
-		args[ 0 ] = selector = [];
+			// JQuery( "#" ) is a bogus ID selector, but it returned an empty set before jQuery 3.0
+			migrateWarn( "jQuery( '#' ) is not a valid selector" );
+			args[ 0 ] = selector = [];
 
-	} else if ( rattrHash.test( selector ) ) {
+		} else if ( rattrHash.test( selector ) ) {
 
-		// The nonstandard and undocumented unquoted-hash was removed in jQuery 1.12.0
-		// Note that this doesn't actually fix the selector due to potential false positives
-		migrateWarn( "Attribute selectors with '#' must be quoted: '" + selector + "'" );
+			// The nonstandard and undocumented unquoted-hash was removed in jQuery 1.12.0
+			// Note that this doesn't actually fix the selector due to potential false positives
+			migrateWarn( "Attribute selectors with '#' must be quoted: '" + selector + "'" );
+		}
 	}
 
 	return oldInit.apply( this, args );

--- a/test/core.js
+++ b/test/core.js
@@ -28,7 +28,7 @@ test( "jQuery( '#' )", function() {
 } );
 
 test( "attribute selectors with naked '#'", function() {
-	expect( 6 );
+	expect( 7 );
 
 	// These are wrapped in try/catch because they throw on jQuery 1.12.0+
 
@@ -65,6 +65,16 @@ test( "attribute selectors with naked '#'", function() {
 	expectNoWarning( "attribute equals, with double quotes", function() {
 		try {
 			jQuery( "a[href=\"#junk\"]" );
+		} catch ( e ) {}
+	} );
+
+	expectNoWarning( "ready function with attribute selector", function() {
+		try {
+			jQuery( function() {
+				if ( jQuery.thisIsNeverTrue ) {
+					jQuery( "a[href=#]" );
+				}
+			} );
 		} catch ( e ) {}
 	} );
 } );


### PR DESCRIPTION
Ref #178 which is a similar problem happening in 1.4, as well as a problem with a variable being set on `document`.

The solution for the 1.x branch is a bit more complicated but I figured I'd fix 3.0 first.