### PR TITLE
Attributes: Fix unquoted hashes in selectors where possible

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1,7 +1,8 @@
 
 var oldInit = jQuery.fn.init,
 	oldIsNumeric = jQuery.isNumeric,
-	rattrHash = /\[(\s*[-\w]+\s*)([~|^$*]?=)\s*([-\w#]+)\s*\]/g;
+	rattrHashTest = /\[(\s*[-\w]+\s*)([~|^$*]?=)\s*([-\w#]*?#[-\w#]*)\s*\]/,
+	rattrHashGlob = /\[(\s*[-\w]+\s*)([~|^$*]?=)\s*([-\w#]*?#[-\w#]*)\s*\]/g;
 
 jQuery.fn.init = function( selector ) {
 	var args = Array.prototype.slice.call( arguments );
@@ -13,8 +14,9 @@ jQuery.fn.init = function( selector ) {
 			migrateWarn( "jQuery( '#' ) is not a valid selector" );
 			args[ 0 ] = selector = [];
 
-		// Can't use .test here because rattrHash is //g and in global scope
-		} else if ( rattrHash.exec( selector ) ) {
+		// Support: PhantomJS 1.x
+		// String#match fails to match when used with a //g RegExp, only on some strings
+		} else if ( rattrHashTest.test( selector ) ) {
 
 			// The nonstandard and undocumented unquoted-hash was removed in jQuery 1.12.0
 			// First see if qS thinks it's a valid selector, if so avoid a false positive
@@ -23,7 +25,7 @@ jQuery.fn.init = function( selector ) {
 			} catch ( err1 ) {
 
 				// Didn't *look* valid to qSA, warn and try quoting what we think is the value
-				selector = selector.replace( rattrHash, function( _, attr, op, value ) {
+				selector = selector.replace( rattrHashGlob, function( _, attr, op, value ) {
 					return "[" + attr + op + "\"" + value + "\"]";
 				} );
 

--- a/src/core.js
+++ b/src/core.js
@@ -1,50 +1,64 @@
 
 var oldInit = jQuery.fn.init,
 	oldIsNumeric = jQuery.isNumeric,
+	oldFind = jQuery.find,
 	rattrHashTest = /\[(\s*[-\w]+\s*)([~|^$*]?=)\s*([-\w#]*?#[-\w#]*)\s*\]/,
 	rattrHashGlob = /\[(\s*[-\w]+\s*)([~|^$*]?=)\s*([-\w#]*?#[-\w#]*)\s*\]/g;
 
-jQuery.fn.init = function( selector ) {
+jQuery.fn.init = function( arg1 ) {
 	var args = Array.prototype.slice.call( arguments );
 
-	if ( typeof selector === "string" ) {
-		if ( selector === "#" ) {
+	if ( typeof arg1 === "string" && arg1 === "#" ) {
 
-			// JQuery( "#" ) is a bogus ID selector, but it returned an empty set before jQuery 3.0
-			migrateWarn( "jQuery( '#' ) is not a valid selector" );
-			args[ 0 ] = selector = [];
-
-		// Support: PhantomJS 1.x
-		// String#match fails to match when used with a //g RegExp, only on some strings
-		} else if ( rattrHashTest.test( selector ) ) {
-
-			// The nonstandard and undocumented unquoted-hash was removed in jQuery 1.12.0
-			// First see if qS thinks it's a valid selector, if so avoid a false positive
-			try {
-				document.querySelector( selector );
-			} catch ( err1 ) {
-
-				// Didn't *look* valid to qSA, warn and try quoting what we think is the value
-				selector = selector.replace( rattrHashGlob, function( _, attr, op, value ) {
-					return "[" + attr + op + "\"" + value + "\"]";
-				} );
-
-				// If the regexp *may* have created an invalid selector, don't update it
-				// Note that there may be false alarms if selector uses jQuery extensions
-				try {
-					document.querySelector( selector );
-					args[ 0 ] = selector;
-					migrateWarn( "Attribute selector with '#' must be quoted: " + selector );
-				} catch ( err2 ) {
-					migrateWarn( "Attribute selector with '#' was not fixed: " + args[ 0 ] );
-				}
-			}
-		}
+		// JQuery( "#" ) is a bogus ID selector, but it returned an empty set before jQuery 3.0
+		migrateWarn( "jQuery( '#' ) is not a valid selector" );
+		args[ 0 ] = [];
 	}
 
 	return oldInit.apply( this, args );
 };
 jQuery.fn.init.prototype = jQuery.fn;
+
+jQuery.find = function( selector ) {
+	var args = Array.prototype.slice.call( arguments );
+
+	// Support: PhantomJS 1.x
+	// String#match fails to match when used with a //g RegExp, only on some strings
+	if ( typeof selector === "string" && rattrHashTest.test( selector ) ) {
+
+		// The nonstandard and undocumented unquoted-hash was removed in jQuery 1.12.0
+		// First see if qS thinks it's a valid selector, if so avoid a false positive
+		try {
+			document.querySelector( selector );
+		} catch ( err1 ) {
+
+			// Didn't *look* valid to qSA, warn and try quoting what we think is the value
+			selector = selector.replace( rattrHashGlob, function( _, attr, op, value ) {
+				return "[" + attr + op + "\"" + value + "\"]";
+			} );
+
+			// If the regexp *may* have created an invalid selector, don't update it
+			// Note that there may be false alarms if selector uses jQuery extensions
+			try {
+				document.querySelector( selector );
+				migrateWarn( "Attribute selector with '#' must be quoted: " + args[ 0 ] );
+				args[ 0 ] = selector;
+			} catch ( err2 ) {
+				migrateWarn( "Attribute selector with '#' was not fixed: " + args[ 0 ] );
+			}
+		}
+	}
+
+	return oldFind.apply( this, args );
+};
+
+// Copy properties attached to original jQuery.find method (e.g. .attr, .isXML)
+var findProp;
+for ( findProp in oldFind ) {
+	if ( Object.prototype.hasOwnProperty.call( oldFind, findProp ) ) {
+		jQuery.find[ findProp ] = oldFind[ findProp ];
+	}
+}
 
 // The number of elements contained in the matched element set
 jQuery.fn.size = function() {

--- a/test/core.js
+++ b/test/core.js
@@ -28,7 +28,7 @@ test( "jQuery( '#' )", function() {
 } );
 
 QUnit.test( "Attribute selectors with unquoted hashes", function( assert ) {
-	expect( 18 );
+	expect( 31 );
 
 	var markup = jQuery(
 			"<div>" +
@@ -53,7 +53,7 @@ QUnit.test( "Attribute selectors with unquoted hashes", function( assert ) {
 		// Fixable, and gives warning
 		fixables = [
 			"a[href=#]",
-			"a[href*=#]:not([href=#]):first-child	",
+			"a[href*=#]:not([href=#]):first-child",
 			".space a[href=#]",
 			"a[href=#some-anchor]",
 			"link[rel*=#stuff]",
@@ -76,18 +76,21 @@ QUnit.test( "Attribute selectors with unquoted hashes", function( assert ) {
 	expectNoWarning( "Perfectly cromulent selectors are unchanged", function() {
 		okays.forEach( function( okay ) {
 			assert.equal( jQuery( okay, markup ).length, 1, okay );
+			assert.equal( markup.find( okay ).length, 1, okay );
 		} );
 	} );
 
 	expectWarning( "Values with unquoted hashes are quoted", fixables.length, function() {
 		fixables.forEach( function( fixable ) {
 			assert.equal( jQuery( fixable, markup ).length, 1, fixable );
+			assert.equal( markup.find( fixable ).length, 1, fixable );
 		} );
 	} );
 
 	expectWarning( "False positives", positives.length, function() {
 		positives.forEach( function( positive ) {
 			assert.equal( jQuery( positive, markup ).length, 1,  positive );
+			assert.equal( markup.find( positive ).length, 1, positive );
 		} );
 	} );
 
@@ -95,8 +98,12 @@ QUnit.test( "Attribute selectors with unquoted hashes", function( assert ) {
 		failures.forEach( function( failure ) {
 			try {
 				jQuery( failure, markup );
-				assert.ok( false, "No Mr. Bond I expect you to die!" );
-			} catch ( err ) { }
+				assert.ok( false, "Expected jQuery() to die!" );
+			} catch ( err1 ) { }
+			try {
+				markup.find( failure );
+				assert.ok( false, "Expected .find() to die!" );
+			} catch ( err2 ) { }
 		} );
 	} );
 

--- a/test/core.js
+++ b/test/core.js
@@ -28,14 +28,24 @@ test( "jQuery( '#' )", function() {
 } );
 
 QUnit.test( "Attribute selectors with unquoted hashes", function( assert ) {
-	expect( 8 );
+	expect( 18 );
 
-	var
+	var markup = jQuery(
+			"<div>" +
+				"<div data-selector='a[href=#main]'></div>" +
+				"<a href='space#junk'>test</a>" +
+				"<link rel='good#stuff' />" +
+				"<p class='space #junk'>" +
+					"<a href='#some-anchor'>anchor2</a>" +
+					"<input value='[strange*=#stuff]' />" +
+					"<a href='#' data-id='#junk'>anchor</a>" +
+				"</p>" +
+			"</div>" ).appendTo( "#qunit-fixture" ),
 
 		// No warning, no need to fix
 		okays = [
-			"a[href='#junk']",
-			"div[data-id=\"#junk\"]",
+			"a[href='#some-anchor']",
+			"[data-id=\"#junk\"]",
 			"div[data-selector='a[href=#main]']",
 			"input[value~= '[strange*=#stuff]']"
 		],
@@ -43,18 +53,18 @@ QUnit.test( "Attribute selectors with unquoted hashes", function( assert ) {
 		// Fixable, and gives warning
 		fixables = [
 			"a[href=#]",
-			"a[href*=#]:not([href=#])",
-			".class a[href=#anchor]",
+			"a[href*=#]:not([href=#]):first-child	",
+			".space a[href=#]",
 			"a[href=#some-anchor]",
 			"link[rel*=#stuff]",
-			"p[class ^= #junk]",
+			"p[class *= #junk]",
 			"a[href=space#junk]"
 		],
 
 		// False positives that still work
 		positives = [
 			"div[data-selector='a[href=#main]']:first",
-			"input[value= '[strange*=#stuff]']:eq(1)"
+			"input[value= '[strange*=#stuff]']:eq(0)"
 		],
 
 		// Failures due to quotes and jQuery extensions combined
@@ -63,30 +73,28 @@ QUnit.test( "Attribute selectors with unquoted hashes", function( assert ) {
 			"a[href=space#junk]:eq(1)"
 		];
 
-	// TODO: ensure these actually select what they should
-
 	expectNoWarning( "Perfectly cromulent selectors are unchanged", function() {
 		okays.forEach( function( okay ) {
-			jQuery( okay );
+			assert.equal( jQuery( okay, markup ).length, 1, okay );
 		} );
 	} );
 
 	expectWarning( "Values with unquoted hashes are quoted", fixables.length, function() {
 		fixables.forEach( function( fixable ) {
-			jQuery( fixable );
+			assert.equal( jQuery( fixable, markup ).length, 1, fixable );
 		} );
 	} );
 
-	expectWarning( "False positives", 2 * positives.length, function() {
+	expectWarning( "False positives", positives.length, function() {
 		positives.forEach( function( positive ) {
-			jQuery( positive );
+			assert.equal( jQuery( positive, markup ).length, 1,  positive );
 		} );
 	} );
 
-	expectWarning( "Unfixable cases", 2 * failures.length, function() {
+	expectWarning( "Unfixable cases", failures.length, function() {
 		failures.forEach( function( failure ) {
 			try {
-				jQuery( failure );
+				jQuery( failure, markup );
 				assert.ok( false, "No Mr. Bond I expect you to die!" );
 			} catch ( err ) { }
 		} );

--- a/warnings.md
+++ b/warnings.md
@@ -27,9 +27,10 @@ This is _not_ a warning, but a console log message the plugin shows when it firs
 
 **Solution:** Remove all but the latest version of the jQuery Migrate plugin. See the [README](https://github.com/jquery/jquery-migrate/#readme) for more information on usage and upgrading from older versions. 
 
-### JQMIGRATE: Attribute selectors with '#' must be quoted
+### JQMIGRATE: Attribute selector with '#' must be quoted
+### JQMIGRATE: Attribute selector with '#' was not fixed
 
-**Cause:** CSS selectors such as `a[href=#main]` are not valid CSS syntax because the value contains special characters that are not quoted. Until jQuery 1.11.3/2.1.4 this syntax was accepted, but the behavior is non-standard and was never documented. In later versions this selector throws an error. *In some rare cases Migrate may mis-diagnose this problem, so it does not attempt a repair.*
+**Cause:** Selectors such as `a[href=#main]` are not valid CSS syntax because the value contains special characters that are not quoted. Until jQuery 1.11.3/2.1.4 this was accepted, but the behavior is non-standard and was never documented. In later versions this selector throws an error. *In some cases with complex selectors, Migrate may not attempt a repair.* In those cases a fatal error will be logged on the console and you will need to fix the selector manually.
 
 **Solution**: Put quotes around any attribute values that have special characters, e.g. `a[href="#main"]`. The warning message contains the selector that caused the problem, use that to find the selector in the source files.
 


### PR DESCRIPTION
Fixes #174 

Still a WIP, I need to contemplate the regex and make the tests a little more better about checking whether the selector works. However I thought it might be good to see if anyone had concerns about this approach.

I left cases alone where I might possibly be breaking the selector even more or silently changing its meaning. However, the current approach does seem to fix all the reported cases in core tickets so far, so it's got that going for it.

A more aggressive approach would be to attempt a change even if the resulting selector isn't `qSA`-acceptable. That covers cases like `a[href=#]:first` that the current code does not. Thoughts?

Given how much this is reported I think it would be good to leave in Migrate 3.0 but also cherry-pick to 1.x.
