### PR TITLE
Serialize: Warn and fill for jQuery.param() use of ajax traditional flag

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -29,6 +29,7 @@ module.exports = function( grunt ) {
 			"src/effects.js",
 			"src/event.js",
 			"src/offset.js",
+			"src/serialize.js",
 			"src/traversing.js",
 			"src/deferred.js",
 			"src/outro.js"

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -1,0 +1,14 @@
+
+var oldParam = jQuery.param;
+
+jQuery.param = function( data, traditional ) {
+	var ajaxTraditional = jQuery.ajaxSettings && jQuery.ajaxSettings.traditional;
+
+	if ( traditional === undefined && ajaxTraditional ) {
+
+		migrateWarn( "jQuery.param() no longer uses jQuery.ajaxSettings.traditional" );
+		traditional = ajaxTraditional;
+	}
+
+	return oldParam.call( this, data, traditional );
+};

--- a/test/index.html
+++ b/test/index.html
@@ -32,6 +32,7 @@
 	<script src="data.js"></script>
 	<script src="event.js"></script>
 	<script src="offset.js"></script>
+	<script src="serialize.js"></script>
 	<script src="traversing.js"></script>
 	<script src="deferred.js"></script>
 	<script src="effects.js"></script>

--- a/test/serialize.js
+++ b/test/serialize.js
@@ -1,0 +1,51 @@
+
+module( "serialize" );
+
+QUnit.test( "jQuery.param( x, traditional)", function( assert ) {
+	assert.expect( 12 );
+
+	var savedTraditional = jQuery.ajaxSettings.traditional,
+		data = { a: [ 1, 2 ] },
+		standardResult = "a%5B%5D=1&a%5B%5D=2",
+		traditionalResult = "a=1&a=2";
+
+	expectNoWarning( "default, traditional default", function() {
+		assert.equal(
+			jQuery.param( data ), standardResult,
+			"default, traditional default" );
+	} );
+
+	expectNoWarning( "explicit true, traditional default", function() {
+		assert.equal(
+			jQuery.param( data, true ), traditionalResult,
+			"explicit true, traditional default" );
+	} );
+
+	expectNoWarning( "explicit false, traditional default", function() {
+		assert.equal(
+			jQuery.param( data, false ), standardResult,
+			"explicit false, traditional default" );
+	} );
+
+	jQuery.ajaxSettings.traditional = true;
+
+	expectWarning( "default, traditional true", function() {
+		assert.equal(
+			jQuery.param( data ), traditionalResult,
+			"default, traditional true	" );
+	} );
+
+	expectNoWarning( "explicit true, traditional true", function() {
+		assert.equal(
+			jQuery.param( data, true ), traditionalResult,
+			"explicit true, traditional true" );
+	} );
+
+	expectNoWarning( "explicit false, traditional true", function() {
+		assert.equal(
+			jQuery.param( data, false ), standardResult,
+			"explicit false, traditional true" );
+	} );
+
+	jQuery.ajaxSettings.traditional = savedTraditional;
+} );

--- a/test/testinit.js
+++ b/test/testinit.js
@@ -29,6 +29,7 @@ TestManager = {
 				"effects",
 				"event",
 				"offset",
+				"serialize",
 				"traversing",
 				"deferred"
 			];

--- a/warnings.md
+++ b/warnings.md
@@ -97,6 +97,12 @@ This is _not_ a warning, but a console log message the plugin shows when it firs
 
 **Solution**: Do not attempt to get or set the offset information of invalid input.
 
+### JQMIGRATE: jQuery.param() no longer uses jQuery.ajaxSettings.traditional
+
+**Cause:** As of jQuery 3.0, the serialization method `jQuery.param` is fully independent of jQuery's ajax module. As a result, it does not look at the `jQuery.ajaxSettings.traditional` flag that affects how form data is encoded. Note that the `jQuery.ajax()` method still honors this flag if you make a request through it.
+
+**Solution:** To continue using the `traditional` flag, pass it explicitly: `jQuery.data( myData, jQuery.ajaxSettings.traditional )`.
+
 ### JQMIGRATE: jQuery.swap() is undocumented and deprecated
 
 **Cause**: The `jQuery.swap()` method temporarily exchanges a set of CSS properties. It was never documented as part of jQuery's public API and should not be used because it can cause performance problems due to forced layout. This method has been removed in jQuery 3.0.


### PR DESCRIPTION
Fixes #173