### PR TITLE
Event: Warn and fill jQuery.event.props and .fixHooks

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -1,4 +1,37 @@
-var oldLoad = jQuery.fn.load;
+var oldLoad = jQuery.fn.load,
+	originalFix = jQuery.event.fix;
+
+// Skip this when testing older 3.0 betas
+if ( jQuery.event.addProp ) {
+
+	jQuery.event.props = [];
+	jQuery.event.fixHooks = {};
+
+	jQuery.event.fix = function( originalEvent ) {
+		var event,
+			type = originalEvent.type,
+			fixHook = this.fixHooks[ type ],
+			props = jQuery.event.props;
+
+		if ( props.length ) {
+			migrateWarn( "jQuery.event.props are deprecated and removed" );
+			while ( props.length ) {
+				jQuery.event.addProp( props.pop() );
+			}
+		}
+
+		if ( fixHook && ( props = fixHook.props ) && props.length ) {
+			migrateWarn( "jQuery.event.fixHooks are deprecated and removed" );
+			while ( props.length ) {
+			   jQuery.event.addProp( props.pop() );
+			}
+		}
+
+		event = originalFix.call( this, originalEvent );
+
+		return fixHook && fixHook.filter ? fixHook.filter( event, originalEvent ) : event;
+	};
+}
 
 jQuery.each( [ "load", "unload", "error" ], function( _, name ) {
 

--- a/test/event-props.html
+++ b/test/event-props.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>jQuery Migrate event props iframe test</title>
+
+	<!-- Load a jQuery and jquery-migrate plugin file based on URL -->
+	<script src="testinit.js"></script>
+	<script>
+		TestManager.loadProject( "jquery", "git" );
+		// Close this script tag so file will load
+	</script>
+	<script>
+		jQuery.noConflict();
+		TestManager.loadProject( "jquery-migrate", "dev", true );
+		// Close this script tag so file will load
+	</script>
+	<script>
+		jQuery.migrateMute = true;
+		jQuery.migrateReset();
+
+		function dispatchEvent( elem, type ) {
+			var e = document.createEvent( "HTMLEvents" );
+			e.initEvent( type, true, true );
+			elem.dispatchEvent( e );
+		}
+
+		function runTest() {
+			var div = document.createElement( "div" ),
+				$div = jQuery( div ).appendTo( document.body );
+
+			jQuery.event.props.push( "genericProp" );
+			jQuery.event.fixHooks[ "excite" ] = {
+				props: [ "reallyHappy", "reallySad" ],
+				filter: function( event, original ) {
+					if ( "reallySad" in event ) {
+						event.gotSad = 1;
+					}
+					if ( "reallyHappy" in event ) {
+						event.gotHappy = 2;
+					}
+					if ( "genericProp" in event ) {
+						event.gotProp = 42;
+					}
+					return event;
+				}
+			};
+
+			$div.on( "excite", function( event ) {
+				var worked =
+
+					// Hooks were called
+					event.gotSad === 1 &&
+					event.gotHappy === 2 &&
+					event.gotProp === 42 &&
+
+					jQuery.event.props.length === 0 &&
+					jQuery.event.fixHooks[ "excite" ].props.length === 0;
+
+				parent.TestManager.iframeCallback( worked );
+			} );
+
+			dispatchEvent( div, "excite" );
+		}
+
+		jQuery( runTest );
+	</script>
+</head>
+<body>
+	<p>jQuery Migrate</p>
+</body>
+</html>

--- a/test/event.js
+++ b/test/event.js
@@ -113,3 +113,14 @@ TestManager.runIframeTest( "document ready", "ready-event.html",
 		assert.ok( fired, "ready event fired" );
 		assert.equal( warnings.length, 1, "warnings: " + JSON.stringify( warnings ) );
 	} );
+
+if ( jQuery.event.addProp ) {
+
+	// Do this as iframe because there is no way to undo prop addition
+	TestManager.runIframeTest( "jQuery.event.props and fixHooks", "event-props.html",
+		function( worked, assert ) {
+			assert.expect( 1 );
+
+			assert.ok( worked, "hooks were installed" );
+		} );
+}

--- a/warnings.md
+++ b/warnings.md
@@ -172,3 +172,10 @@ See jQuery-ui [commit](https://github.com/jquery/jquery-ui/commit/c0093b599fcd58
 **Cause:** Calling `.toggleClass()` with no arguments, or with a single Boolean `true` or `false` argument, has been deprecated. Its behavior was poorly documented, but essentially the method saved away the current `class` value in a data item when the class was removed and restored the saved value when it was toggled back. If you do not believe you are specificially trying to use this form of the method, it is possible you are accidentally doing so via an inadvertent undefined value, as `.toggleClass( undefined )` toggles all classes.
 
 **Solution:** If this functionality is still needed, save the current full `.attr( "class" )` value in a data item and restore it when required.
+
+### JQMIGRATE: jQuery.event.props are deprecated and removed
+### JQMIGRATE: jQuery.event.fixHooks are deprecated and removed
+
+**Cause:** The code on the page has added one or more properties to the `jQuery.event.props` or `jQuery.event.fixHooks` data structures. These were used in previous versions to affect the properties that are copied from the native event to the jQuery event each time an event is delivered, but they had the potential to create performance issues. An improved API will be announced in a future version of jQuery.
+
+**Solution:** The most popular use of these data structures are to add properties for touch or pointer events, and those properties are now supported by default with a newer high-performance approach in jQuery 3.0 that only retrieves the properties on first access. If you are using plugins such as [pointerTouch](https://github.com/timmywil/jquery.event.pointertouch) or [touchHooks](https://github.com/aarongloege/jquery.touchHooks), simply remove them as they are no longer needed.


### PR DESCRIPTION
Fixes #187 

I've updated the warnings file with the assumption that https://github.com/jquery/jquery/issues/3104 happens which I strongly recommend.