### PR TITLE
Tests: Refactor iframe tests to be more like core

### DIFF
--- a/test/core.js
+++ b/test/core.js
@@ -273,8 +273,8 @@ test( "jQuery.expr.pseudos aliases", function( assert ) {
 } );
 
 TestManager.runIframeTest( "old pre-3.0 jQuery", "old-jquery.html",
-	function( logOutput, assert ) {
+	function( assert, jQuery, window, document, log ) {
 		assert.expect( 1 );
 
-		assert.ok( /jQuery 3/.test( logOutput ), "logged: " + logOutput );
+		assert.ok( /jQuery 3/.test( log ), "logged: " + log );
 	} );

--- a/test/event-props.html
+++ b/test/event-props.html
@@ -8,17 +8,13 @@
 	<script src="testinit.js"></script>
 	<script>
 		TestManager.loadProject( "jquery", "git" );
-		// Close this script tag so file will load
 	</script>
+	<script src="iframeTest.js"></script>
 	<script>
 		jQuery.noConflict();
 		TestManager.loadProject( "jquery-migrate", "dev", true );
-		// Close this script tag so file will load
 	</script>
 	<script>
-		jQuery.migrateMute = true;
-		jQuery.migrateReset();
-
 		function dispatchEvent( elem, type ) {
 			var e = document.createEvent( "HTMLEvents" );
 			e.initEvent( type, true, true );
@@ -57,7 +53,7 @@
 					jQuery.event.props.length === 0 &&
 					jQuery.event.fixHooks[ "excite" ].props.length === 0;
 
-				parent.TestManager.iframeCallback( worked );
+				startIframeTest( worked );
 			} );
 
 			dispatchEvent( div, "excite" );

--- a/test/event.js
+++ b/test/event.js
@@ -107,20 +107,19 @@ test( "custom ready", function() {
 } );
 
 TestManager.runIframeTest( "document ready", "ready-event.html",
-	function( fired, warnings, assert ) {
-		assert.expect( 2 );
+	function( assert, jQuery, window, document, log ) {
+		assert.expect( 1 );
 
-		assert.ok( fired, "ready event fired" );
-		assert.equal( warnings.length, 1, "warnings: " + JSON.stringify( warnings ) );
+		assert.equal( jQuery.migrateWarnings.length, 1, "warnings: " +
+			JSON.stringify( jQuery.migrateWarnings ) );
 	} );
 
-if ( jQuery.event.addProp ) {
+// Do this as iframe because there is no way to undo prop addition
+TestManager.runIframeTest( "jQuery.event.props and fixHooks", "event-props.html",
+	function( assert, jQuery, window, document, log, worked ) {
+		assert.expect( 2 );
 
-	// Do this as iframe because there is no way to undo prop addition
-	TestManager.runIframeTest( "jQuery.event.props and fixHooks", "event-props.html",
-		function( worked, assert ) {
-			assert.expect( 1 );
-
-			assert.ok( worked, "hooks were installed" );
-		} );
-}
+		assert.ok( worked, "hooks were installed" );
+		assert.equal( jQuery.migrateWarnings.length, 2, "warnings: " +
+			JSON.stringify( jQuery.migrateWarnings ) );
+	} );

--- a/test/iframeTest.js
+++ b/test/iframeTest.js
@@ -1,0 +1,29 @@
+/*
+ * Iframe-based unit tests support
+ * Load this file immediately after jQuery, before jQuery Migrate
+ */
+
+// Warning messages are available to parent test in jQuery.migrateWarnings
+jQuery.migrateMute = true;
+
+// Support: IE9 only (no console at times)
+if ( !window.console ) {
+	window.console = {};
+}
+
+// Capture output so the test in the parent window can inspect it, and so the
+// initialization for the iframe doesn't show another Migrate startup header.
+var logOutput = "";
+
+window.console.log = function() {
+	logOutput += Array.prototype.join.call( arguments, " " ) + "\n";
+};
+
+// Callback gets ( jQuery, window, document, log [, startIframe args ] )
+window.startIframeTest = function() {
+	var args = Array.prototype.slice.call( arguments );
+
+	// Note: jQuery may be undefined if page did not load it
+	args.unshift( window.jQuery, window, document, logOutput );
+	window.parent.TestManager.iframeCallback.apply( null, args );
+};

--- a/test/old-jquery.html
+++ b/test/old-jquery.html
@@ -3,31 +3,18 @@
 <head>
 	<meta charset="utf-8">
 	<title>jQuery Migrate old-jQuery initialization test</title>
-	<script>
-		// Capture log output to ensure we warned on old jQuery
-		var logOutput = "";
-
-		// Support: IE9 only (no console at times)
-		if ( !window.console ) {
-			window.console = {};
-		}
-
-		window.console.log = function() {
-			logOutput += Array.prototype.join.call( arguments, " " ) + "\n";
-		};
-	</script>
 
 	<!-- Load older jQuery, then jquery-migrate plugin file based on URL -->
 	<script src="./data/jquery-2.2.3.js"></script>
+	<script src="iframeTest.js"></script>
 	<script src="testinit.js"></script>
 	<script>
 		jQuery.noConflict();
 		TestManager.loadProject( "jquery-migrate", "dev", true );
-		// Close this script tag so file will load
 	</script>
 	<script>
 		// Should have logged during initialization
-		parent.TestManager.iframeCallback( logOutput );
+		startIframeTest();
 	</script>
 </head>
 <body>

--- a/test/ready-event.html
+++ b/test/ready-event.html
@@ -8,18 +8,16 @@
 	<script src="testinit.js"></script>
 	<script>
 		TestManager.loadProject( "jquery", "git" );
-		// Close this script tag so file will load
 	</script>
+	<script src="iframeTest.js"></script>
 	<script>
 		jQuery.noConflict();
 		TestManager.loadProject( "jquery-migrate", "dev", true );
-		// Close this script tag so file will load
 	</script>
 	<script>
-		jQuery.migrateMute = true;
-		jQuery.migrateReset();
+		// This should warn when the handler runs
 		jQuery( document ).on( "ready", function() {
-			parent.TestManager.iframeCallback( true, jQuery.migrateWarnings );
+			startIframeTest();
 		} );
 	</script>
 </head>

--- a/test/testinit.js
+++ b/test/testinit.js
@@ -78,7 +78,7 @@ TestManager = {
 			self.iframeCallback = function() {
 				var args = Array.prototype.slice.call( arguments );
 
-				args.push( assert );
+				args.unshift( assert );
 
 				setTimeout( function() {
 					self.iframeCallback = undefined;


### PR DESCRIPTION
This makes the arg order and basic approach closer to what is now being used in
core. It also removes some of the boilerplate from the iframe html pages and
moves it to a new iframeTest.js file that they all include.