### PR TITLE
Add support for integrating with external reporting

### DIFF
--- a/src/migrate.js
+++ b/src/migrate.js
@@ -49,7 +49,7 @@ function migrateWarn( msg ) {
 	if ( !warnedAbout[ msg ] ) {
 		warnedAbout[ msg ] = true;
 		jQuery.migrateWarnings.push( msg );
-		jQuery.migrateWarnings.asErrors.push( msg );
+		jQuery.migrateWarnings.asErrors.push( new Error( msg ) );
 		if ( console && console.warn && !jQuery.migrateMute ) {
 			console.warn( "JQMIGRATE: " + msg );
 			if ( jQuery.migrateTrace && console.trace ) {

--- a/src/migrate.js
+++ b/src/migrate.js
@@ -31,6 +31,7 @@ var warnedAbout = {};
 
 // List of warnings already given; public read only
 jQuery.migrateWarnings = [];
+jQuery.migrateWarnings.asErrors = [];
 
 // Set to false to disable traces that appear with warnings
 if ( jQuery.migrateTrace === undefined ) {
@@ -40,16 +41,15 @@ if ( jQuery.migrateTrace === undefined ) {
 // Forget any warnings we've already given; public
 jQuery.migrateReset = function() {
 	warnedAbout = {};
-	jQuery.migrateWarnings.length = 0;
+	jQuery.migrateWarnings.length = jQuery.migrateWarnings.asErrors.length = 0;
 };
 
 function migrateWarn( msg ) {
 	var console = window.console;
 	if ( !warnedAbout[ msg ] ) {
 		warnedAbout[ msg ] = true;
-		var msgObj = new String(msg);
-		msgObj.asError = new Error(msg);
-		jQuery.migrateWarnings.push( msgObj );
+		jQuery.migrateWarnings.push( msg );
+		jQuery.migrateWarnings.asErrors.push( msg );
 		if ( console && console.warn && !jQuery.migrateMute ) {
 			console.warn( "JQMIGRATE: " + msg );
 			if ( jQuery.migrateTrace && console.trace ) {

--- a/src/migrate.js
+++ b/src/migrate.js
@@ -47,13 +47,16 @@ function migrateWarn( msg ) {
 	var console = window.console;
 	if ( !warnedAbout[ msg ] ) {
 		warnedAbout[ msg ] = true;
-		jQuery.migrateWarnings.push( msg );
+		var msgObj = new String(msg);
+		msgObj.asError = new Error(msg);
+		jQuery.migrateWarnings.push( msgObj );
 		if ( console && console.warn && !jQuery.migrateMute ) {
 			console.warn( "JQMIGRATE: " + msg );
 			if ( jQuery.migrateTrace && console.trace ) {
 				console.trace();
 			}
 		}
+		jQuery(window).trigger("migrateWarning");
 	}
 }
 

--- a/src/migrate.js
+++ b/src/migrate.js
@@ -56,7 +56,7 @@ function migrateWarn( msg ) {
 				console.trace();
 			}
 		}
-		jQuery(window).trigger("migrateWarning");
+		jQuery( window ).trigger( "migrateWarning" );
 	}
 }
 

--- a/test/ajax.js
+++ b/test/ajax.js
@@ -1,7 +1,7 @@
 module( "ajax" );
 
 test( "jQuery.ajax() deprecations on jqXHR", function( assert ) {
-	assert.expect( 3 );
+	assert.expect( 4 );
 
 	var done = assert.async();
 

--- a/test/attributes.js
+++ b/test/attributes.js
@@ -2,7 +2,7 @@
 QUnit.module( "attributes" );
 
 QUnit.test( ".removeAttr( boolean attribute )", function( assert ) {
-	assert.expect( 8 );
+	assert.expect( 9 );
 
 	expectNoWarning( "non-boolean attr", function() {
 		var $div = jQuery( "<div />" )
@@ -43,7 +43,7 @@ QUnit.test( ".removeAttr( boolean attribute )", function( assert ) {
 } );
 
 QUnit.test( ".toggleClass( boolean )", function( assert ) {
-	assert.expect( 14 );
+	assert.expect( 17 );
 
 	var e = jQuery( "<div />" ).appendTo( "#qunit-fixture" );
 

--- a/test/core.js
+++ b/test/core.js
@@ -28,7 +28,7 @@ test( "jQuery( '#' )", function() {
 } );
 
 QUnit.test( "Attribute selectors with unquoted hashes", function( assert ) {
-	expect( 31 );
+	expect( 34 );
 
 	var markup = jQuery(
 			"<div>" +

--- a/test/data.js
+++ b/test/data.js
@@ -16,7 +16,7 @@ test( "jQuery.data() camelCased names", function( assert ) {
 			"-dashy-hanger"
 		];
 
-	assert.expect( 16 );
+	assert.expect( 17 );
 
 	var curData,
 		div = document.createElement( "div" );

--- a/test/event.js
+++ b/test/event.js
@@ -53,7 +53,7 @@ test( "load() and unload() event methods", function( assert ) {
 } );
 
 QUnit.test( ".bind() and .unbind()", function( assert ) {
-	assert.expect( 3 );
+	assert.expect( 5 );
 
 	var $elem = jQuery( "<div />" ).appendTo( "#qunit-fixture" );
 
@@ -73,7 +73,7 @@ QUnit.test( ".bind() and .unbind()", function( assert ) {
 } );
 
 QUnit.test( ".delegate() and .undelegate()", function( assert ) {
-	assert.expect( 3 );
+	assert.expect( 5 );
 
 	var $div = jQuery( "<div />" ).appendTo( "#qunit-fixture" );
 

--- a/test/migrate.js
+++ b/test/migrate.js
@@ -19,6 +19,7 @@ function expectWarning( name, expected, fn ) {
 	// Simple numeric equality assertion for warnings matching an explicit count
 	} else if ( expected && jQuery.migrateWarnings.length === expected ) {
 		equal( jQuery.migrateWarnings.length, expected, name + ": warned" );
+		equal( jQuery.migrateWarnings.asErrors.length, expected, name + ": warned as Errors" );
 
 	// Simple ok assertion when we saw at least one warning and weren't looking for an explict count
 	} else if ( !expected && jQuery.migrateWarnings.length ) {


### PR DESCRIPTION
We use Raygun to record JavaScript errors. It would be nice to have migrate warnings there too. Raygun likes Error objects - and we like stack traces - so save Error objects in parallel with the warning messages in migrateWarn() and also raise an event that a listener can trigger on to extract the data & send it wherever it wishes.