### PR TITLE
Core: Use migrateWarnFunc for warning on function call, not access

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -6,11 +6,11 @@ jQuery.ajax = function( ) {
 
 	// Be sure we got a jQXHR (e.g., not sync)
 	if ( jQXHR.promise ) {
-		migrateWarnProp( jQXHR, "success", jQXHR.done,
+		migrateWarnFunc( jQXHR, "success", jQXHR.done,
 			"jQXHR.success is deprecated and removed" );
-		migrateWarnProp( jQXHR, "error", jQXHR.fail,
+		migrateWarnFunc( jQXHR, "error", jQXHR.fail,
 			"jQXHR.error is deprecated and removed" );
-		migrateWarnProp( jQXHR, "complete", jQXHR.always,
+		migrateWarnFunc( jQXHR, "complete", jQXHR.always,
 			"jQXHR.complete is deprecated and removed" );
 	}
 

--- a/src/core.js
+++ b/src/core.js
@@ -89,7 +89,7 @@ jQuery.isNumeric = function( val ) {
 	return oldValue;
 };
 
-migrateWarnProp( jQuery, "unique", jQuery.uniqueSort,
+migrateWarnFunc( jQuery, "unique", jQuery.uniqueSort,
 	"jQuery.unique is deprecated, use jQuery.uniqueSort" );
 
 // Now jQuery.expr.pseudos is the standard incantation

--- a/src/migrate.js
+++ b/src/migrate.js
@@ -68,6 +68,13 @@ function migrateWarnProp( obj, prop, value, msg ) {
 	} );
 }
 
+function migrateWarnFunc( obj, prop, newFunc, msg ) {
+	obj[ prop ] = function() {
+		migrateWarn( msg );
+		return newFunc.apply( this, arguments );
+	};
+}
+
 if ( document.compatMode === "BackCompat" ) {
 
 	// JQuery has never supported or tested Quirks Mode


### PR DESCRIPTION
Unit tests already were using calls, so no changes were needed there.

migrateWarnFunc will be used in a lot of the 3.2 deprecations.