### PR TITLE
Traces: commas replaced by semi-colons

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -62,7 +62,7 @@ for ( findProp in oldFind ) {
 
 // The number of elements contained in the matched element set
 jQuery.fn.size = function() {
-	migrateWarn( "jQuery.fn.size() is deprecated and removed, use the .length property" );
+	migrateWarn( "jQuery.fn.size() is deprecated and removed; use the .length property" );
 	return this.length;
 };
 
@@ -90,10 +90,10 @@ jQuery.isNumeric = function( val ) {
 };
 
 migrateWarnFunc( jQuery, "unique", jQuery.uniqueSort,
-	"jQuery.unique is deprecated, use jQuery.uniqueSort" );
+	"jQuery.unique is deprecated; use jQuery.uniqueSort" );
 
 // Now jQuery.expr.pseudos is the standard incantation
 migrateWarnProp( jQuery.expr, "filters", jQuery.expr.pseudos,
-	"jQuery.expr.filters is deprecated, use jQuery.expr.pseudos" );
+	"jQuery.expr.filters is deprecated; use jQuery.expr.pseudos" );
 migrateWarnProp( jQuery.expr, ":", jQuery.expr.pseudos,
-	"jQuery.expr[':'] is deprecated, use jQuery.expr.pseudos" );
+	"jQuery.expr[':'] is deprecated; use jQuery.expr.pseudos" );

--- a/warnings.md
+++ b/warnings.md
@@ -79,7 +79,7 @@ This is _not_ a warning, but a console log message the plugin shows when it firs
 
 **Solution**: Replace any use of `.andSelf()` with `.addBack()`.
 
-### JQMIGRATE: jQuery.fn.size() is deprecated and removed, use the .length property
+### JQMIGRATE: jQuery.fn.size() is deprecated and removed; use the .length property
 
 **Cause**: The `.size()` method returns the number of elements in the current jQuery object, but duplicates the more-efficient `.length` property which provides the same functionality. As of jQuery 1.9 the `.length` property is the preferred way to retrieve this value. jQuery 3.0 no longer contains the `.size()` method.
 
@@ -173,8 +173,8 @@ See jQuery-ui [commit](https://github.com/jquery/jquery-ui/commit/c0093b599fcd58
 
 **Solution**: Replace all uses of `jQuery.unique` with `jQuery.uniqueSort` which is the same function with a better name.
 
-### JQMIGRATE: jQuery.expr[':'] is deprecated, use jQuery.expr.pseudos
-### JQMIGRATE: jQuery.expr.filters is deprecated, use jQuery.expr.pseudos
+### JQMIGRATE: jQuery.expr[':'] is deprecated; use jQuery.expr.pseudos
+### JQMIGRATE: jQuery.expr.filters is deprecated; use jQuery.expr.pseudos
 
 **Cause:** The standard way to add new custom selectors through jQuery is `jQuery.expr.pseudos`. These two other aliases are deprecated, although they still work as of jQuery 3.0.
 


### PR DESCRIPTION
Standardization of the trace text shape to facilitate textual search into https://github.com/jquery/jquery-migrate/blob/1.x-stable/warnings.md
I arbitrary chose the semi-colon as a sentence separator. This is not important, the goal is to be homogeneous between the sources and the documentation, because there is at least one inconsistency with "JQMIGRATE: jQuery.parseJSON is deprecated; use JSON.parse", that I want to fix too.