### PR TITLE
Docs: Remove reference to deprecated `.ready()` method

### DIFF
--- a/warnings.md
+++ b/warnings.md
@@ -129,7 +129,7 @@ This is _not_ a warning, but a console log message the plugin shows when it firs
 
 **Cause**: Using one of jQuery's API methods to bind a "ready" event, e.g. `$( document ).on( "ready", fn )`, will cause the function to be called when the document is ready, but only if it is attached before the browser fires its own `DOMContentLoaded` event. That makes it unreliable for many uses, particularly ones where jQuery or its plugins are loaded asynchronously after page load.
 
-**Solution**: Replace any use of `$( document ).on( "ready", fn )` with `$( document ).ready( fn )` or more simply, just `$( fn )`. These alternative methods work reliably even when the document is already loaded.
+**Solution**: Replace any use of `$( document ).on( "ready", fn )` with `$( fn )`. This approach works reliably even when the document is already loaded.
 
 ### JQMIGRATE: Additional params for 'jQuery.easing' functions are not documented and redundant
 


### PR DESCRIPTION
Fixes #221
