### PR TITLE
Build: Followup to #206, fix jQuery dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
 		"test": "grunt test",
 		"ci": "grunt ci"
 	},
-	"dependencies": {
-		"jquery": "3.0.0"
+	"peerDependencies": {
+		"jquery": ">3.0.0"
 	},
 	"devDependencies": {
 		"chalk": "1.1.3",
@@ -39,7 +39,7 @@
 		"grunt-jscs": "2.8.0",
 		"grunt-npmcopy": "0.1.0",
 		"grunt-qunit-istanbul": "0.6.0",
-		"jquery": "2.2.4",
+		"jquery": "3.1.1",
 		"phantomjs-polyfill": "0.0.2",
 		"qunitjs": "1.23.1",
 		"testswarm": "1.1.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"ci": "grunt ci"
 	},
 	"peerDependencies": {
-		"jquery": ">3.0.0"
+		"jquery": ">=3 <4"
 	},
 	"devDependencies": {
 		"chalk": "1.1.3",


### PR DESCRIPTION
Is this along the lines of what you were thinking in https://github.com/jquery/jquery-migrate/pull/206#issuecomment-246420065 @mgol? Since we are pulling the actual dependencies from the CDN for testing, we don't actually use these npm-installed copies.