### PR TITLE
Bugfix/easing compatibility

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -1,6 +1,6 @@
 var oldTweenRun = jQuery.Tween.prototype.run;
 
-jQuery.Tween.prototype.run = function( percent ) {
+jQuery.Tween.prototype.run = function( ) {
 	if ( jQuery.easing[ this.easing ].length > 1 ) {
 		migrateWarn(
 			"easing function " +
@@ -8,15 +8,11 @@ jQuery.Tween.prototype.run = function( percent ) {
 			"\" should use only first argument"
 		);
 
-			jQuery.easing[ this.easing ] = jQuery.easing[ this.easing ].bind(
-				jQuery.easing,
-				percent, this.options.duration * percent, 0, 1, this.options.duration
-			);
-		// var oldEasing = jQuery.easing[ this.easing ];
-		// jQuery.easing[ this.easing ] = function( newPercent ) {
-		//   return oldEasing.call( jQuery.easing,
-		//     newPercent, newPercent, 0, 1, 1 );
-		// }.bind( this );
+		var oldEasing = jQuery.easing[ this.easing ];
+		jQuery.easing[ this.easing ] = function( percent ) {
+		  return oldEasing.call( jQuery.easing,
+		    percent, percent, 0, 1, 1 );
+		}.bind( this );
 	}
 
 	oldTweenRun.apply( this, arguments );

--- a/src/effects.js
+++ b/src/effects.js
@@ -8,10 +8,15 @@ jQuery.Tween.prototype.run = function( percent ) {
 			"\" should use only first argument"
 		);
 
-		jQuery.easing[ this.easing ] = jQuery.easing[ this.easing ].bind(
-			jQuery.easing,
-			percent, this.options.duration * percent, 0, 1, this.options.duration
-		);
+			jQuery.easing[ this.easing ] = jQuery.easing[ this.easing ].bind(
+				jQuery.easing,
+				percent, this.options.duration * percent, 0, 1, this.options.duration
+			);
+		// var oldEasing = jQuery.easing[ this.easing ];
+		// jQuery.easing[ this.easing ] = function( newPercent ) {
+		//   return oldEasing.call( jQuery.easing,
+		//     newPercent, newPercent, 0, 1, 1 );
+		// }.bind( this );
 	}
 
 	oldTweenRun.apply( this, arguments );

--- a/test/effects.js
+++ b/test/effects.js
@@ -1,13 +1,31 @@
 module( "effects" );
 
 QUnit.test( "jQuery.easing", function( assert ) {
-	assert.expect( 5 );
+	var lastP = false,
+		easingCallCount = 0;
+		animComplete = assert.async();
+
+	assert.expect( 7 );
 
 	jQuery.easing.test = function( p, n, firstNum, diff ) {
-		assert.notEqual( p, undefined );
-		assert.notEqual( n, undefined );
-		assert.notEqual( firstNum, undefined );
-		assert.notEqual( diff, undefined );
+
+		// First frame of animation
+		if ( easingCallCount === 0 ){
+			assert.equal( p, 0 );
+			assert.notEqual( n, undefined );
+			assert.notEqual( firstNum, undefined );
+			assert.notEqual( diff, undefined);
+
+		// Second frame of animation. (Only check once so we know how many assertions to expect.)
+		}else if (easingCallCount === 1){
+			assert.ok( p > 0 );
+
+		}
+		lastP = p;
+		easingCallCount++;
+
+		// Linear
+		return p;
 	};
 
 	var div = jQuery( "<div>test</div>" );
@@ -15,7 +33,14 @@ QUnit.test( "jQuery.easing", function( assert ) {
 	div.appendTo( "#qunit-fixture" );
 
 	expectWarning( "easing", function() {
-		div.animate( { width: 20 }, 10, "test" );
+		div.animate( { width: 20 }, {
+			duration: 100,
+			easing: "test",
+			complete: function() {
+				assert.equal( lastP, 1 );
+				animComplete();
+			}
+		} );
 	} );
 } );
 
@@ -53,4 +78,3 @@ QUnit.test( "jQuery.fx.interval - user change", function( assert ) {
 
 	jQuery.fx.interval = oldInterval;
 } );
-

--- a/test/effects.js
+++ b/test/effects.js
@@ -2,7 +2,7 @@ module( "effects" );
 
 QUnit.test( "jQuery.easing", function( assert ) {
 	var lastP = false,
-		easingCallCount = 0;
+		easingCallCount = 0,
 		animComplete = assert.async();
 
 	assert.expect( 7 );
@@ -10,14 +10,14 @@ QUnit.test( "jQuery.easing", function( assert ) {
 	jQuery.easing.test = function( p, n, firstNum, diff ) {
 
 		// First frame of animation
-		if ( easingCallCount === 0 ){
+		if ( easingCallCount === 0 ) {
 			assert.equal( p, 0 );
 			assert.notEqual( n, undefined );
 			assert.notEqual( firstNum, undefined );
-			assert.notEqual( diff, undefined);
+			assert.notEqual( diff, undefined );
 
 		// Second frame of animation. (Only check once so we know how many assertions to expect.)
-		}else if (easingCallCount === 1){
+		}else if ( easingCallCount === 1 ) {
 			assert.ok( p > 0 );
 
 		}


### PR DESCRIPTION
Addresses bug #233 by listening for the current percent that the easing function should be called with, rather than using the percent passed to jQuery.Tween.prototype.run, which will always be 0.

The expanded test asserts that calls to the easing function come through with 0 the first time, >0 the second time, and after the animation has completed, that it was most recently called with 1.
