### PR TITLE
Data: Support object as second argument

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -2,9 +2,21 @@ var oldData = jQuery.data;
 
 jQuery.data = function( elem, name, value ) {
 	var curData;
+	
+	//name can be an object, and each entry in the object is meant to be set as data
+	if ( name && typeof name === 'object' && arguments.length === 2 ) {
+		for ( var key in name ) {
+			if ( key !== jQuery.camelCase( key ) ){
+				migrateWarn( "jQuery.data() always sets/gets camelCased names: " + key );
+			}
+		}
+		
+		//jQuery.data will convert keys to camelCase, and this is a setter.	
+		return oldData.apply( this, arguments );
+	}
 
 	// If the name is transformed, look for the un-transformed name in the data object
-	if ( name && name !== jQuery.camelCase( name ) ) {
+	if ( name && typeof name === 'string' && name !== jQuery.camelCase( name ) ) {
 		curData = jQuery.hasData( elem ) && oldData.call( this, elem );
 		if ( curData && name in curData ) {
 			migrateWarn( "jQuery.data() always sets/gets camelCased names: " + name );

--- a/src/data.js
+++ b/src/data.js
@@ -2,16 +2,16 @@ var oldData = jQuery.data;
 
 jQuery.data = function( elem, name, value ) {
 	var curData;
-	
-	//name can be an object, and each entry in the object is meant to be set as data
+
+	//Name can be an object, and each entry in the object is meant to be set as data
 	if ( name && typeof name === "object" && arguments.length === 2 ) {
 		for ( var key in name ) {
-			if ( key !== jQuery.camelCase( key ) ){
+			if ( key !== jQuery.camelCase( key ) ) {
 				migrateWarn( "jQuery.data() always sets/gets camelCased names: " + key );
 			}
 		}
-		
-		//jQuery.data will convert keys to camelCase, and this is a setter.	
+
+		//Original jQuery.data will convert keys to camelCase, and this is a setter.
 		return oldData.apply( this, arguments );
 	}
 

--- a/src/data.js
+++ b/src/data.js
@@ -5,14 +5,20 @@ jQuery.data = function( elem, name, value ) {
 
 	//Name can be an object, and each entry in the object is meant to be set as data
 	if ( name && typeof name === "object" && arguments.length === 2 ) {
+		curData = jQuery.hasData( elem ) && oldData.call( this, elem );
+		var sameKeys = {};
 		for ( var key in name ) {
 			if ( key !== jQuery.camelCase( key ) ) {
 				migrateWarn( "jQuery.data() always sets/gets camelCased names: " + key );
+				curData[ key ] = name[ key ];
+			} else {
+				sameKeys[ key ] = name[ key ];
 			}
 		}
 
-		//Original jQuery.data will convert keys to camelCase, and this is a setter.
-		return oldData.apply( this, arguments );
+		oldData.call( this, elem, sameKeys );
+
+		return name;
 	}
 
 	// If the name is transformed, look for the un-transformed name in the data object

--- a/src/data.js
+++ b/src/data.js
@@ -4,7 +4,7 @@ jQuery.data = function( elem, name, value ) {
 	var curData;
 	
 	//name can be an object, and each entry in the object is meant to be set as data
-	if ( name && typeof name === 'object' && arguments.length === 2 ) {
+	if ( name && typeof name === "object" && arguments.length === 2 ) {
 		for ( var key in name ) {
 			if ( key !== jQuery.camelCase( key ) ){
 				migrateWarn( "jQuery.data() always sets/gets camelCased names: " + key );
@@ -16,7 +16,7 @@ jQuery.data = function( elem, name, value ) {
 	}
 
 	// If the name is transformed, look for the un-transformed name in the data object
-	if ( name && typeof name === 'string' && name !== jQuery.camelCase( name ) ) {
+	if ( name && typeof name === "string" && name !== jQuery.camelCase( name ) ) {
 		curData = jQuery.hasData( elem ) && oldData.call( this, elem );
 		if ( curData && name in curData ) {
 			migrateWarn( "jQuery.data() always sets/gets camelCased names: " + name );

--- a/src/data.js
+++ b/src/data.js
@@ -3,7 +3,7 @@ var oldData = jQuery.data;
 jQuery.data = function( elem, name, value ) {
 	var curData;
 
-	//Name can be an object, and each entry in the object is meant to be set as data
+	// Name can be an object, and each entry in the object is meant to be set as data
 	if ( name && typeof name === "object" && arguments.length === 2 ) {
 		curData = jQuery.hasData( elem ) && oldData.call( this, elem );
 		var sameKeys = {};

--- a/test/data.js
+++ b/test/data.js
@@ -37,6 +37,23 @@ test( "jQuery.data() camelCased names", function( assert ) {
 		} );
 	} );
 
+	div = document.createElement( "div" );
+
+	// = sames.length + diffs.length + noWarning
+	expectNoWarning( "Data set as an object and get without warning via API", function() {
+		var testData = {};
+
+		sames.concat( diffs ).forEach( function( name, index ) {
+			testData[ name ] = index;
+		} );
+
+		jQuery.data( div, testData );
+
+		sames.concat( diffs ).forEach( function( name, index ) {
+			assert.equal( jQuery.data( div, name ), index, name + "=" + index );
+		} );
+	} );
+
 	// Camelized values set for all names above, get the data object
 	curData = jQuery.data( div );
 

--- a/test/data.js
+++ b/test/data.js
@@ -16,7 +16,7 @@ test( "jQuery.data() camelCased names", function( assert ) {
 			"-dashy-hanger"
 		];
 
-	assert.expect( 27 );
+	assert.expect( 16 );
 
 	var curData,
 		div = document.createElement( "div" );
@@ -37,7 +37,38 @@ test( "jQuery.data() camelCased names", function( assert ) {
 		} );
 	} );
 
-	div = document.createElement( "div" );
+	// Camelized values set for all names above, get the data object
+	curData = jQuery.data( div );
+
+	// = diffs.length + warning
+	expectWarning( "Dashed name conflicts", diffs.length, function() {
+		diffs.forEach( function( name, index ) {
+			curData[ name ] = index;
+			assert.equal( jQuery.data( div, name ), curData[ name ],
+				name + " respects data object" );
+		} );
+	} );
+
+} );
+
+test( "jQuery.data() camelCased names (mass setter)", function( assert ) {
+	var sames = [
+			"datum",
+			"ropeAdope",
+			"Олег\u0007Michał",
+			"already-Big",
+			"number-2",
+			"unidash-"
+		],
+		diffs = [
+			"dat-data",
+			"hangy-dasher-",
+			"-dashy-hanger"
+		];
+
+	assert.expect( 11 );
+
+	var div = document.createElement( "div" );
 
 	// = sames.length + noWarning
 	expectNoWarning( "Data set as an object and get without warning via API", function() {
@@ -69,16 +100,5 @@ test( "jQuery.data() camelCased names", function( assert ) {
 		} );
 	} );
 
-	// Camelized values set for all names above, get the data object
-	curData = jQuery.data( div );
-
-	// = diffs.length + warning
-	expectWarning( "Dashed name conflicts", diffs.length, function() {
-		diffs.forEach( function( name, index ) {
-			curData[ name ] = index;
-			assert.equal( jQuery.data( div, name ), curData[ name ],
-				name + " respects data object" );
-		} );
-	} );
-
 } );
+

--- a/test/data.js
+++ b/test/data.js
@@ -39,17 +39,32 @@ test( "jQuery.data() camelCased names", function( assert ) {
 
 	div = document.createElement( "div" );
 
-	// = sames.length + diffs.length + noWarning
+	// = sames.length + noWarning
 	expectNoWarning( "Data set as an object and get without warning via API", function() {
 		var testData = {};
 
-		sames.concat( diffs ).forEach( function( name, index ) {
+		sames.forEach( function( name, index ) {
 			testData[ name ] = index;
 		} );
 
 		jQuery.data( div, testData );
 
-		sames.concat( diffs ).forEach( function( name, index ) {
+		sames.forEach( function( name, index ) {
+			assert.equal( jQuery.data( div, name ), index, name + "=" + index );
+		} );
+	} );
+
+	// = diffs.length + noWarning
+	expectWarning( "Data set as an object and get without warning via API", function() {
+		var testData = {};
+
+		diffs.forEach( function( name, index ) {
+			testData[ name ] = index;
+		} );
+
+		jQuery.data( div, testData );
+
+		diffs.forEach( function( name, index ) {
 			assert.equal( jQuery.data( div, name ), index, name + "=" + index );
 		} );
 	} );

--- a/test/data.js
+++ b/test/data.js
@@ -16,7 +16,7 @@ test( "jQuery.data() camelCased names", function( assert ) {
 			"-dashy-hanger"
 		];
 
-	assert.expect( 16 );
+	assert.expect( 27 );
 
 	var curData,
 		div = document.createElement( "div" );
@@ -54,7 +54,7 @@ test( "jQuery.data() camelCased names", function( assert ) {
 		} );
 	} );
 
-	// = diffs.length + noWarning
+	// = diffs.length + warning
 	expectWarning( "Data set as an object and get without warning via API", function() {
 		var testData = {};
 


### PR DESCRIPTION
jQuery.data supports passing an object as a second argument and sets data for each entry in that object.

This warns the user about each violating non-camelCase key in the object.

This also adds a type check to avoid a current bug where jQuery.camelCase throws an error because a non-string is passed to it.
