### PR TITLE
Deferred: Preserve exceptionHook

### DIFF
--- a/src/deferred.js
+++ b/src/deferred.js
@@ -54,3 +54,5 @@ jQuery.Deferred = function( func ) {
 	return deferred;
 };
 
+// Preserve handler of uncaught exceptions in promise chains
+jQuery.Deferred.exceptionHook = oldDeferred.exceptionHook;


### PR DESCRIPTION
Deferred.exceptionHook was added in jQuery 3 to log errors that were silently swallowed inside of promise chains. This preserves that feature for consistency.