### PR TITLE
Build: Make release script create CDN directory if missing

### DIFF
--- a/build/release.js
+++ b/build/release.js
@@ -32,9 +32,10 @@ var releaseVersion,
 	devFile = "dist/jquery-migrate.js",
 	minFile = "dist/jquery-migrate.min.js",
 
+	releaseDir = "CDN/",
 	releaseFiles = {
-		"CDN/jquery-migrate-VER.js": devFile,
-		"CDN/jquery-migrate-VER.min.js": minFile
+		"jquery-migrate-VER.js": devFile,
+		"jquery-migrate-VER.min.js": minFile
 	};
 
 steps(
@@ -162,8 +163,11 @@ function gruntBuild( next ) {
 
 function makeReleaseCopies( next ) {
 	finalFiles = {};
+	if ( !fs.existsSync( releaseDir ) ) {
+		fs.mkdirSync( releaseDir );
+	}
 	Object.keys( releaseFiles ).forEach( function( key ) {
-		var builtFile = releaseFiles[ key ],
+		var builtFile = releaseDir + releaseFiles[ key ],
 			releaseFile = key.replace( /VER/g, releaseVersion );
 
 		copy( builtFile, releaseFile );


### PR DESCRIPTION
Currently until the directory is manually created:

```
$ node build/release.js 3.0.1
Current version is 3.0.1-pre; generating release 3.0.1
(...)
Copying dist/jquery-migrate.js to CDN/jquery-migrate-3.0.1.js
Error: ENOENT: no such file or directory, open 'CDN/jquery-migrate-3.0.1.js'
    at Object.fs.openSync (fs.js:652:18)
```