### PR TITLE
Effects: Don't warn about interval if document is hidden

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -15,11 +15,25 @@ jQuery.Tween.prototype.run = function( ) {
 	oldTweenRun.apply( this, arguments );
 };
 
-jQuery.fx.interval = jQuery.fx.interval || 13;
+var intervalValue = jQuery.fx.interval || 13,
+	intervalMsg = "jQuery.fx.interval is deprecated";
 
 // Support: IE9, Android <=4.4
 // Avoid false positives on browsers that lack rAF
+// Don't warn if document is hidden, jQuery uses setTimeout (#292)
 if ( window.requestAnimationFrame ) {
-	migrateWarnProp( jQuery.fx, "interval", jQuery.fx.interval,
-		"jQuery.fx.interval is deprecated" );
+	Object.defineProperty( jQuery.fx, "interval", {
+		configurable: true,
+		enumerable: true,
+		get: function() {
+			if ( !window.document.hidden ) {
+				migrateWarn( intervalMsg );
+			}
+			return intervalValue;
+		},
+		set: function( newValue ) {
+			migrateWarn( intervalMsg );
+			intervalValue = newValue;
+		}
+	} );
 }


### PR DESCRIPTION
Fixes #292 

This seems like the easiest way to avoid the spurious error. There's no change to the tests because the current tests fire as they did before, the document isn't hidden. The test is already skipped for IE9 but if it wasn't then `document.hidden` would be falsy there anyway.

In the latest spec it looks like `document.hidden` has been [somewhat obsoleted](https://www.w3.org/TR/page-visibility/#hidden-attribute) but is still supported.