### PR TITLE
Build: Support jQuery 3.4.1 and use 3.x for grunt test

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,7 +30,7 @@ module.exports = function( grunt ) {
 			jquery: [
 				"dev+3.x-git",
 				"min+3.x-git.min",
-				"dev+3.4.0",
+				"dev+3.4.1",
 				"dev+3.3.1",
 				"dev+3.2.1",
 				"dev+3.1.1",
@@ -116,7 +116,7 @@ module.exports = function( grunt ) {
 				},
 				frameworks: [ "qunit" ],
 				files: [
-					"https://code.jquery.com/jquery-git.min.js",
+					"https://code.jquery.com/jquery-3.x-git.min.js",
 					"dist/jquery-migrate.min.js",
 					"src/compareVersions.js",
 

--- a/test/testinit.js
+++ b/test/testinit.js
@@ -139,7 +139,7 @@ TestManager = {
 TestManager.init( {
 	"jquery": {
 		urlTag: "jquery",
-		choices: "dev,min,git,3.x-git,3.4.0,3.3.1,3.2.1,3.1.1,3.0.0"
+		choices: "dev,min,git,3.x-git,3.4.1,3.3.1,3.2.1,3.1.1,3.0.0"
 	},
 	"jquery-migrate": {
 		urlTag: "plugin",


### PR DESCRIPTION
Since `jquery-git.js` already has some 4.x breaking changes we need to avoid using it.

I'm seeing one test failure locally on `grunt test` related to `jQuery.event.props.concat` but it's happening on 3.4.0 as well. I don't see any failures on real browsers though.

The most recent Jenkins job failed as well but I don't see anything in the output to explain it: http://jenkins.jquery.com/job/jQuery%20Migrate/412/console

