### PR TITLE
Core: Get pre-4.0 compat by implementing removed functions

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -84,18 +84,20 @@ migrateWarnProp( jQuery.expr, ":", jQuery.expr.pseudos,
 
 // Prior to jQuery 3.2 there were internal refs so we don't warn there
 if ( jQueryVersionSince( "3.2.0" ) ) {
-	migrateWarnFunc( jQuery, "nodeName", jQuery.nodeName,
+	migrateWarnFunc( jQuery, "nodeName", function( elem, name ) {
+		return elem.nodeName && elem.nodeName.toLowerCase() === name.toLowerCase();
+	},
 	"jQuery.nodeName is deprecated" );
 }
 
 if ( jQueryVersionSince( "3.3.0" ) ) {
 
-	migrateWarnFunc( jQuery, "isNumeric", jQuery.isNumeric = function( obj ) {
+	migrateWarnFunc( jQuery, "isNumeric", function( obj ) {
 
 			// As of jQuery 3.0, isNumeric is limited to
 			// strings and numbers (primitives or objects)
 			// that can be coerced to finite numbers (gh-2662)
-			var type = jQuery.type( obj );
+			var type = typeof obj;
 			return ( type === "number" || type === "string" ) &&
 
 				// parseFloat NaNs numeric-cast false positives ("")
@@ -106,10 +108,30 @@ if ( jQueryVersionSince( "3.3.0" ) ) {
 		"jQuery.isNumeric() is deprecated"
 	);
 
-	migrateWarnFunc( jQuery, "type", jQuery.type,
+	// Populate the class2type map
+	var class2type = {};
+	jQuery.each( "Boolean Number String Function Array Date RegExp Object Error Symbol".
+		split( " " ),
+	function( _, name ) {
+		class2type[ "[object " + name + "]" ] = name.toLowerCase();
+	} );
+
+	migrateWarnFunc( jQuery, "type", function( obj ) {
+		if ( obj == null ) {
+			return obj + "";
+		}
+
+		// Support: Android <=2.3 only (functionish RegExp)
+		return typeof obj === "object" || typeof obj === "function" ?
+			class2type[ Object.prototype.toString.call( obj ) ] || "object" :
+			typeof obj;
+	},
 	"jQuery.type is deprecated" );
 
-	migrateWarnFunc( jQuery, "isFunction", jQuery.isFunction,
+	migrateWarnFunc( jQuery, "isFunction",
+		function( obj ) {
+			return typeof obj === "function";
+		},
 		"jQuery.isFunction() is deprecated" );
 
 	migrateWarnFunc( jQuery, "isWindow",

--- a/src/data.js
+++ b/src/data.js
@@ -1,5 +1,11 @@
 var oldData = jQuery.data;
 
+var camelCase = function( string ) {
+	return string.replace( /-([a-z])/g, function( _, letter ) {
+		return letter.toUpperCase();
+	} );
+};
+
 jQuery.data = function( elem, name, value ) {
 	var curData;
 
@@ -8,7 +14,7 @@ jQuery.data = function( elem, name, value ) {
 		curData = jQuery.hasData( elem ) && oldData.call( this, elem );
 		var sameKeys = {};
 		for ( var key in name ) {
-			if ( key !== jQuery.camelCase( key ) ) {
+			if ( key !== camelCase( key ) ) {
 				migrateWarn( "jQuery.data() always sets/gets camelCased names: " + key );
 				curData[ key ] = name[ key ];
 			} else {
@@ -22,7 +28,7 @@ jQuery.data = function( elem, name, value ) {
 	}
 
 	// If the name is transformed, look for the un-transformed name in the data object
-	if ( name && typeof name === "string" && name !== jQuery.camelCase( name ) ) {
+	if ( name && typeof name === "string" && name !== camelCase( name ) ) {
 		curData = jQuery.hasData( elem ) && oldData.call( this, elem );
 		if ( curData && name in curData ) {
 			migrateWarn( "jQuery.data() always sets/gets camelCased names: " + name );

--- a/src/deferred.js
+++ b/src/deferred.js
@@ -22,14 +22,14 @@ jQuery.Deferred = function( func ) {
 
 		return jQuery.Deferred( function( newDefer ) {
 			jQuery.each( tuples, function( i, tuple ) {
-				var fn = jQuery.isFunction( fns[ i ] ) && fns[ i ];
+				var fn = typeof fns[ i ] === "function" && fns[ i ];
 
 				// Deferred.done(function() { bind to newDefer or newDefer.resolve })
 				// deferred.fail(function() { bind to newDefer or newDefer.reject })
 				// deferred.progress(function() { bind to newDefer or newDefer.notify })
 				deferred[ tuple[ 1 ] ]( function() {
 					var returned = fn && fn.apply( this, arguments );
-					if ( returned && jQuery.isFunction( returned.promise ) ) {
+					if ( returned && typeof returned.promise === "function" ) {
 						returned.promise()
 							.done( newDefer.resolve )
 							.fail( newDefer.reject )


### PR DESCRIPTION
If possible I'd like to avoid having Migrate 3 break when used on jQuery 4. That was inevitable with jQuery 1/2 and Migrate 1 because we changed the behaviors of several APIs which made it impossible to sanely build Migrate 3 on Migrate 1. I think we can do better here.

This PR adds the jQuery core implementation and unit tests for `jQuery.type`, `jQuery.isNumeric`, and `jQuery.nodeName`. It also removes the Migrate internal references to those APIs. For now at least, this runs against jQuery pre-4.x master.