### PR TITLE
Offset: fix wrong origin value

### DIFF
--- a/src/offset.js
+++ b/src/offset.js
@@ -4,17 +4,17 @@ var oldOffset = jQuery.fn.offset;
 jQuery.fn.offset = function() {
 	var docElem,
 		elem = this[ 0 ],
-		origin = { top: 0, left: 0 };
+		bogus = { top: 0, left: 0 };
 
 	if ( !elem || !elem.nodeType ) {
 		migrateWarn( "jQuery.fn.offset() requires a valid DOM element" );
-		return origin;
+		return undefined;
 	}
 
 	docElem = ( elem.ownerDocument || window.document ).documentElement;
 	if ( !jQuery.contains( docElem, elem ) ) {
 		migrateWarn( "jQuery.fn.offset() requires an element connected to a document" );
-		return origin;
+		return bogus;
 	}
 
 	return oldOffset.apply( this, arguments );

--- a/test/offset.js
+++ b/test/offset.js
@@ -25,9 +25,9 @@ QUnit.test( ".offset()", function( assert ) {
 	} );
 
 	expectWarning( assert, ".offset() on window", function() {
-		assert.deepEqual(
+		assert.strictEqual(
 			jQuery( window ).offset(),
-			bogus, "window bogus top/left 0"
+			undefined, "window undefined"
 		);
 	} );
 
@@ -38,10 +38,10 @@ QUnit.test( ".offset()", function( assert ) {
 		);
 	} );
 
-	expectWarning( assert, ".offset() on plain object", function() {
-		assert.deepEqual(
+	expectWarning(assert, ".offset() on plain object", function () {
+		assert.strictEqual(
 			jQuery( { space: "junk", zero: 0 } ).offset(),
-			bogus, "plain object bogus top/left 0"
+			undefined, "plain object undefined"
 		);
 	} );
 } );


### PR DESCRIPTION
Fixes #330 .

`offset` should return `undefined` instead of `{top:0,left:0}` for non DOM element.