### PR TITLE
Build: Test on jQuery 4.x separately to jQuery 3.x

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,9 +30,12 @@ module.exports = function( grunt ) {
 		tests: {
 			jquery: [
 				"dev+git",
-				"min+git.min",
+				"min+git.min"
+			],
+			"jquery-3": [
 				"dev+3.x-git",
 				"min+3.x-git.min",
+				"dev+3.5.0",
 				"dev+3.4.1",
 				"dev+3.3.1",
 				"dev+3.2.1",

--- a/build/tasks/testswarm.js
+++ b/build/tasks/testswarm.js
@@ -19,7 +19,9 @@ module.exports = function( grunt ) {
 			browserSets = JSON.parse( browserSets );
 		}
 		timeout = timeout || 1000 * 60 * 15;
-		tests = grunt.config( "tests" ).jquery;
+		tests = grunt.config( "tests" )[
+			Array.isArray( browserSets ) ? browserSets[ 0 ] : browserSets ||
+				"jquery" ];
 
 		if ( pull ) {
 			jobName = "Pull <a href='https://github.com/jquery/jquery-migrate/pull/" +

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "jquery-migrate",
-	"version": "3.1.1-pre",
+	"version": "3.2.1-pre",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -3208,9 +3208,9 @@
 			"dev": true
 		},
 		"jquery": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-			"integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
+			"integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==",
 			"dev": true
 		},
 		"js-reporters": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"grunt-contrib-watch": "1.1.0",
 		"grunt-eslint": "21.0.0",
 		"grunt-karma": "3.0.2",
-		"jquery": "3.4.1",
+		"jquery": "3.5.0",
 		"karma": "4.1.0",
 		"karma-browserstack-launcher": "1.5.1",
 		"karma-chrome-launcher": "2.2.0",

--- a/test/testinit.js
+++ b/test/testinit.js
@@ -157,7 +157,7 @@ TestManager = {
 TestManager.init( {
 	"jquery": {
 		urlTag: "jquery",
-		choices: "dev,min,git,3.x-git,3.x-git.min,3.4.1,3.3.1,3.2.1,3.1.1,3.0.0"
+		choices: "dev,min,git,git.min,3.x-git,3.x-git.min,3.5.0,3.4.1,3.3.1,3.2.1,3.1.1,3.0.0"
 	},
 	"jquery-migrate": {
 		urlTag: "plugin",


### PR DESCRIPTION
Having separate test runs for those jQuery lines is necessary as they support
different browsers. Android 4.0 fails hard when run against jQuery master code.

A git.min version was also added to aid manual testing.

I've already modified Jenkins jobs to adhere to what this PR does. I renamed the existing "jQuery Migrate" to "jQuery Migrate - 4.x core" & created a new "jQuery Migrate - 3.x core" job. Both jobs will now fire for every new Migrate commit.

I run a test run on my fork and both jobs passed:
jQuery Migrate - 4.x core: http://swarm.jquery.org/job/9632
jQuery Migrate - 3.x core: http://swarm.jquery.org/job/9633