### PR TITLE
Core: detect incorrectly nested elements

### DIFF
--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -4,18 +4,22 @@ var rxhtmlTag = /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([a-z][^\/\
 		var doc = window.document.implementation.createHTMLDocument( "" );
 		doc.body.innerHTML = html;
 		return doc.body && doc.body.innerHTML;
+	},
+	warnIfChanged = function( html ) {
+		var changed = html.replace( rxhtmlTag, "<$1></$2>" );
+		if ( changed !== html && makeMarkup( html ) !== makeMarkup( changed ) ) {
+			migrateWarn( "HTML tags must be properly nested and closed: " + html );
+		}
 	};
 
 jQuery.UNSAFE_restoreLegacyHtmlPrefilter = function() {
 	jQuery.htmlPrefilter = function( html ) {
+		warnIfChanged( html );
 		return html.replace( rxhtmlTag, "<$1></$2>" );
 	};
 };
 
 jQuery.htmlPrefilter = function( html ) {
-	var changed = html.replace( rxhtmlTag, "<$1></$2>" );
-	if ( changed !== html && makeMarkup( html ) !== makeMarkup( changed ) ) {
-		migrateWarn( "HTML tags must be properly nested and closed: " + html );
-	}
+	warnIfChanged( html );
 	return origHtmlPrefilter( html );
 };

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -1,7 +1,21 @@
-var rxhtmlTag = /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([a-z][^\/\0>\x20\t\r\n\f]*)[^>]*)\/>/gi;
+var rxhtmlTag = /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([a-z][^\/\0>\x20\t\r\n\f]*)[^>]*)\/>/gi,
+	origHtmlPrefilter = jQuery.htmlPrefilter,
+	makeMarkup = function( html ) {
+		var doc = window.document.implementation.createHTMLDocument( "" );
+		doc.body.innerHTML = html;
+		return doc.body && doc.body.innerHTML;
+	};
 
 jQuery.UNSAFE_restoreLegacyHtmlPrefilter = function() {
 	jQuery.htmlPrefilter = function( html ) {
 		return html.replace( rxhtmlTag, "<$1></$2>" );
 	};
+};
+
+jQuery.htmlPrefilter = function( html ) {
+	var changed = html.replace( rxhtmlTag, "<$1></$2>" );
+	if ( changed !== html && makeMarkup( html ) !== makeMarkup( changed ) ) {
+		migrateWarn( "HTML tags must be properly nested and closed: " + html );
+	}
+	return origHtmlPrefilter( html );
 };

--- a/test/manipulation.js
+++ b/test/manipulation.js
@@ -2,6 +2,42 @@
 
 QUnit.module( "manipulation" );
 
+QUnit.test( "Improperly closed elements", function( assert ) {
+	assert.expect( 4 );
+
+	var oldWindowAlert = window.alert;
+	window.alert = function() {
+		assert.notOk( "Called alert with " + arguments );
+	};
+
+	expectWarning( assert, "Elements not self-closable nested wrong", 4, function() {
+		jQuery( "<div><p/><span/></div>" );
+		jQuery( "<blockquote><p class='bad' /><span/></blockquote>" );
+		jQuery( "<div />" ).append( "<div data-borked='y'><span/> <p/></div>" );
+		jQuery( "<script /><div class=afterscript/>" );
+	} );
+
+	expectNoWarning( assert, "Script doesn't run in processed strings", function() {
+		jQuery( "<script>alert( 'YOU SHOULD NOT SEE THIS ALERT' )</script>" );
+		jQuery( "<div>" ).append( "<script src='YOU-SHOULD-NOT-SEE-THIS.SCRIPT'></script>" );
+		jQuery( "<script>alert( 'YOU SHOULD NOT SEE THIS CONSOLE' )</script>" );
+	} );
+
+	expectNoWarning( assert, "Elements not self-closable but tolerable", function() {
+		jQuery( "<div class=wonky />" );
+		jQuery( "<p style='width: 2%' />" );
+		jQuery( "<p />" ).append( "<span aria-label='hello' />" );
+	} );
+
+	expectNoWarning( assert, "Bare elements", function() {
+		jQuery( "<p/>" ).append( "<strong>" );
+		jQuery( "<abbr />" );
+		jQuery( "<head />" );
+	} );
+
+	window.alert = oldWindowAlert;
+} );
+
 // Do this as iframe because there is no way to undo `jQuery.UNSAFE_restoreLegacyHtmlPrefilter()`
 TestManager.runIframeTest( "jQuery.UNSAFE_restoreLegacyHtmlPrefilter",
 	"manipulation-UNSAFE_restoreLegacyHtmlPrefilter.html",

--- a/test/manipulation.js
+++ b/test/manipulation.js
@@ -42,9 +42,14 @@ QUnit.test( "Improperly closed elements", function( assert ) {
 TestManager.runIframeTest( "jQuery.UNSAFE_restoreLegacyHtmlPrefilter",
 	"manipulation-UNSAFE_restoreLegacyHtmlPrefilter.html",
 	function( assert, jQuery, window, document, log, childCount, firstNodeName, secondNodeName ) {
-		assert.expect( 3 );
+		assert.expect( 5 );
+
+		var warns = jQuery.migrateWarnings;
 
 		assert.strictEqual( childCount, 2, "Proper child count" );
 		assert.strictEqual( firstNodeName, "div", "Proper first element" );
 		assert.strictEqual( secondNodeName, "span", "Proper second element" );
+
+		assert.equal( warns.length, 1, "Proper warning length" );
+		assert.ok( warns[ 0 ].indexOf( "HTML tags" ) >= 0, warns[ 0 ] );
 	} );

--- a/warnings.md
+++ b/warnings.md
@@ -259,3 +259,9 @@ See jQuery-ui [commit](https://github.com/jquery/jquery-ui/commit/c0093b599fcd58
 **Cause:** In past versions, when a number-typed value was passed to `.css()` jQuery converted it to a string and added `"px"` to the end. As the CSS standard has evolved, an increasingly large set of CSS properties now accept values that are unitless numbers, where this behavior is incorrect. It has become impractical to manage these exceptions in the `jQuery.cssNumber` object. In addition, some CSS properties like `line-height` can accept both a bare number `2` or a pixel value `2px`. jQuery cannot know the correct way to interpret `$.css("line-height", 2)` and currently treats it as `"2px"`.
 
 **Solution:** Always pass string values to `.css()`, and explicitly add units where required. For example, use `$.css("line-height", "2")` to specify 200% of the current line height or `$.css("line-height", "2px")` to specify pixels. When the numeric value is in a variable, ensure the value is converted to string, e.g. `$.css("line-height", String(height))` and `$.css("line-height", height+"px")`.
+
+#### JQMIGRATE: HTML tags must be properly nested and closed: _(HTML string)_
+
+**Cause:** jQuery 3.5.0 changed the way it processes HTML strings. Previously, jQuery would attempt to fix self-closed tags like `<i class="test" />` that the HTML5 specification says are not self-closed, turning it into `<i class="test"></i>`. This processing can create a [security problem](https://nvd.nist.gov/vuln/detail/CVE-2020-11022) with malicious strings, so the functionality had to be removed.
+
+**Solution:** Search for the reported HTML strings and edit the tags to close them explicitly. In some cases the strings passed to jQuery may be created inside the program and thus not searchable. Migrate warning messages include a stack trace that can be used to find the location of the usage in the code. 


### PR DESCRIPTION
Basic approach: If our old `jQuery.htmlPrefilter` would have changed the string _and_ the resulting actual HTML string is different, give a warning.