### PR TITLE
Build: Remove a deprecated `sudo` key in the Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
-sudo: false
 node_js:
 - "8"
 addons:


### PR DESCRIPTION
That will resolve Travis config warnings; see e.g.:
https://travis-ci.org/github/jquery/jquery-migrate/jobs/674773008/config