### PR TITLE
Build: Migrate sources to ES modules, use a Rollup-based build system

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,7 +2,5 @@ coverage
 external
 node_modules
 *.min.js
-src/intro.js
-src/outro.js
 test/data/jquery-*.js
 test/data/jquery.mobile-*.js

--- a/.eslintrc-browser.json
+++ b/.eslintrc-browser.json
@@ -18,13 +18,11 @@
 	"env": {},
 
 	"globals": {
-		"window": true,
-		"define": true,
-		"module": true
+		"window": true
 	},
 
 	"rules": {
-		"one-var": ["error", {"var": "always"}],
-		"strict": ["error", "function"]
+		"one-var": [ "error", { "var": "always" } ],
+		"strict": [ "error", "function" ]
 	}
 }

--- a/.eslintrc-node.json
+++ b/.eslintrc-node.json
@@ -4,7 +4,7 @@
 	"extends": "jquery",
 
 	"parserOptions": {
-		"ecmaVersion": 2017
+		"ecmaVersion": 2018
 	},
 
 	"env": {

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ CDN
 *.patch
 /*.html
 .DS_Store
+.sizecache.json
 
 # Ignore everything in dist folder except for eslint config
 /dist/*

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,30 +4,23 @@
 
 module.exports = function( grunt ) {
 
-	var isTravis = process.env.TRAVIS;
+	const gzip = require( "gzip-js" );
+	const isTravis = process.env.TRAVIS;
 
 	// Project configuration.
 	grunt.initConfig( {
 		pkg: grunt.file.readJSON( "package.json" ),
-		files: [
-			"src/intro.js",
-			"src/version.js",
-			"src/compareVersions.js",
-			"src/migrate.js",
-			"src/core.js",
-			"src/ajax.js",
-			"src/attributes.js",
-			"src/css.js",
-			"src/data.js",
-			"src/effects.js",
-			"src/event.js",
-			"src/manipulation.js",
-			"src/offset.js",
-			"src/serialize.js",
-			"src/traversing.js",
-			"src/deferred.js",
-			"src/outro.js"
-		],
+		compare_size: {
+			files: [ "dist/jquery-migrate.js", "dist/jquery-migrate.min.js" ],
+			options: {
+				compress: {
+					gz: function( contents ) {
+						return gzip.zip( contents, {} ).length;
+					}
+				},
+				cache: "build/.sizecache.json"
+			}
+		},
 		tests: {
 			jquery: [
 				"dev+git",
@@ -56,6 +49,12 @@ module.exports = function( grunt ) {
 			dist: {
 				src: "<%= files %>",
 				dest: "dist/<%= pkg.name %>.js"
+			}
+		},
+		build: {
+			all: {
+				src: "src/migrate.js",
+				dest: "dist/jquery-migrate.js"
 			}
 		},
 		qunit: {
@@ -125,7 +124,7 @@ module.exports = function( grunt ) {
 				files: [
 					"https://code.jquery.com/jquery-3.x-git.min.js",
 					"dist/jquery-migrate.min.js",
-					"src/compareVersions.js",
+					"test/data/compareVersions.js",
 
 					"test/testinit.js",
 					"test/migrate.js",
@@ -203,10 +202,15 @@ module.exports = function( grunt ) {
 		"eslint:dev",
 		"eslint:dist"
 	] );
-	grunt.registerTask( "build", [ "concat", "uglify", "lint" ] );
 
-	grunt.registerTask( "default", [ "build", "test" ] );
+	grunt.registerTask( "default", [
+		"build",
+		"uglify",
+		"lint",
+		"compare_size",
+		"test"
+	] );
 
 	// For CI
-	grunt.registerTask( "ci", [ "build", "test" ] );
+	grunt.registerTask( "ci", [ "default" ] );
 };

--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -1,0 +1,72 @@
+/**
+ * A build task that compiles jQuery Migrate JS modules into one bundle.
+ */
+
+"use strict";
+
+module.exports = function( grunt ) {
+	const path = require( "path" );
+	const rollup = require( "rollup" );
+	const rootFolder = path.resolve( `${ __dirname }/../..` );
+	const srcFolder = path.resolve( `${ rootFolder }/src` );
+	const read = function( fileName ) {
+		return grunt.file.read( `${ srcFolder }/${ fileName }` );
+	};
+
+	// Catch `// @CODE` and subsequent comment lines event if they don't start
+	// in the first column.
+	const wrapper = read( "wrapper.js" )
+		.split( /[\x20\t]*\/\/ @CODE\n(?:[\x20\t]*\/\/[^\n]+\n)*/ );
+
+	const inputRollupOptions = {};
+	const outputRollupOptions = {
+
+		// The ESM format is not actually used as we strip it during
+		// the build; it's just that it doesn't generate any extra
+		// wrappers so there's nothing for us to remove.
+		format: "esm",
+
+		intro: wrapper[ 0 ]
+			.replace( /\n*$/, "" ),
+		outro: wrapper[ 1 ]
+			.replace( /^\n*/, "" )
+	};
+
+	grunt.registerMultiTask(
+		"build",
+		"Build jQuery Migrate ECMAScript modules, embed date/version",
+	async function() {
+		const done = this.async();
+
+		try {
+			const version = grunt.config( "pkg.version" );
+			const dest = this.files[ 0 ].dest;
+			const src = this.files[ 0 ].src[ 0 ];
+
+			inputRollupOptions.input = path.resolve( `${ rootFolder }/${ src }` );
+
+			const bundle = await rollup.rollup( inputRollupOptions );
+
+			const { output: [ { code } ] } = await bundle.generate( outputRollupOptions );
+
+			const compiledContents = code
+
+				// Embed Version
+				.replace( /@VERSION/g, version )
+
+				// Embed Date
+				// yyyy-mm-ddThh:mmZ
+				.replace(
+					/@DATE/g,
+					( new Date() ).toISOString()
+						.replace( /:\d+\.\d+Z$/, "Z" )
+				);
+
+			grunt.file.write( `${ rootFolder }/${ dest }`, compiledContents );
+			grunt.log.ok( `File '${ dest }' created.` );
+			done();
+		} catch ( err ) {
+			done( err );
+		}
+	} );
+};

--- a/dist/.eslintrc.json
+++ b/dist/.eslintrc.json
@@ -1,6 +1,20 @@
 {
-	"extends": "../src/.eslintrc.json",
 	"root": true,
+
+	"extends": "../src/.eslintrc.json",
+
+	"parserOptions": {
+		"ecmaVersion": 5,
+		"sourceType": "script"
+	},
+
+	"globals": {
+		"define": false,
+		"module": true,
+		"Proxy": false,
+		"Reflect": false
+	},
+
 	"rules": {
 		// That is okay for the built version
 		"no-multiple-empty-lines": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,9 +77,9 @@
 			"dev": true
 		},
 		"ajv": {
-			"version": "6.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-			"integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+			"version": "6.12.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+			"integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
 			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
@@ -194,6 +194,70 @@
 			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
 			"dev": true
 		},
+		"array-includes": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
+			"integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0",
+				"is-string": "^1.0.5"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.17.5",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+					"integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.1.5",
+						"is-regex": "^1.0.5",
+						"object-inspect": "^1.7.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
+						"string.prototype.trimleft": "^2.1.1",
+						"string.prototype.trimright": "^2.1.1"
+					}
+				},
+				"es-to-primitive": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+					"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+					"dev": true,
+					"requires": {
+						"is-callable": "^1.1.4",
+						"is-date-object": "^1.0.1",
+						"is-symbol": "^1.0.2"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+					"dev": true
+				},
+				"is-callable": {
+					"version": "1.1.5",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+					"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+					"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+					"dev": true,
+					"requires": {
+						"has": "^1.0.3"
+					}
+				}
+			}
+		},
 		"array-slice": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
@@ -211,6 +275,69 @@
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
 			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
 			"dev": true
+		},
+		"array.prototype.flat": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
+			"integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.1"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.17.5",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+					"integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.1.5",
+						"is-regex": "^1.0.5",
+						"object-inspect": "^1.7.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
+						"string.prototype.trimleft": "^2.1.1",
+						"string.prototype.trimright": "^2.1.1"
+					}
+				},
+				"es-to-primitive": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+					"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+					"dev": true,
+					"requires": {
+						"is-callable": "^1.1.4",
+						"is-date-object": "^1.0.1",
+						"is-symbol": "^1.0.2"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+					"dev": true
+				},
+				"is-callable": {
+					"version": "1.1.5",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+					"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+					"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+					"dev": true,
+					"requires": {
+						"has": "^1.0.3"
+					}
+				}
+			}
 		},
 		"arraybuffer.slice": {
 			"version": "0.0.7",
@@ -631,9 +758,9 @@
 			}
 		},
 		"cli-width": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+			"integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
 			"dev": true
 		},
 		"coffeescript": {
@@ -763,6 +890,12 @@
 				"utils-merge": "1.0.1"
 			}
 		},
+		"contains-path": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+			"dev": true
+		},
 		"content-type": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
@@ -797,6 +930,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
+		},
+		"crc32": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/crc32/-/crc32-0.2.2.tgz",
+			"integrity": "sha1-etIg1v/c0Rn5/BJ6d3LKzqOQpLo=",
 			"dev": true
 		},
 		"cross-spawn": {
@@ -919,6 +1058,12 @@
 					}
 				}
 			}
+		},
+		"deflate-js": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/deflate-js/-/deflate-js-0.2.3.tgz",
+			"integrity": "sha1-+Fq7WOvFFRowYUdHPVfD5PfkQms=",
+			"dev": true
 		},
 		"delayed-stream": {
 			"version": "0.0.5",
@@ -1242,10 +1387,179 @@
 			}
 		},
 		"eslint-config-jquery": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-jquery/-/eslint-config-jquery-2.0.0.tgz",
-			"integrity": "sha512-HrUTma5Ty6A91M3dTWz3Ot7YnpbsDQGIQDI8JyLKiuUltVXuKCs3yC7uHugp5/0RfYAPLisxHv7giNGvaqM4CA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-jquery/-/eslint-config-jquery-3.0.0.tgz",
+			"integrity": "sha512-VDdRAIlNq1EM5P7J4JGQSCnZEIvIlNGGTUTCPT2wQNZ2GT69rsAwSIqZVcoiyZbwY7TaaMwLOxwSjqm+DEUjbA==",
 			"dev": true
+		},
+		"eslint-import-resolver-node": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz",
+			"integrity": "sha512-b8crLDo0M5RSe5YG8Pu2DYBj71tSB6OvXkfzwbJU2w7y8P4/yo0MyF8jU26IEuEuHF2K5/gcAJE3LhQGqBBbVg==",
+			"dev": true,
+			"requires": {
+				"debug": "^2.6.9",
+				"resolve": "^1.13.1"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.17.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+					"dev": true,
+					"requires": {
+						"path-parse": "^1.0.6"
+					}
+				}
+			}
+		},
+		"eslint-module-utils": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
+			"integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+			"dev": true,
+			"requires": {
+				"debug": "^2.6.9",
+				"pkg-dir": "^2.0.0"
+			}
+		},
+		"eslint-plugin-import": {
+			"version": "2.20.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.2.tgz",
+			"integrity": "sha512-FObidqpXrR8OnCh4iNsxy+WACztJLXAHBO5hK79T1Hc77PgQZkyDGA5Ag9xAvRpglvLNxhH/zSmZ70/pZ31dHg==",
+			"dev": true,
+			"requires": {
+				"array-includes": "^3.0.3",
+				"array.prototype.flat": "^1.2.1",
+				"contains-path": "^0.1.0",
+				"debug": "^2.6.9",
+				"doctrine": "1.5.0",
+				"eslint-import-resolver-node": "^0.3.2",
+				"eslint-module-utils": "^2.4.1",
+				"has": "^1.0.3",
+				"minimatch": "^3.0.4",
+				"object.values": "^1.1.0",
+				"read-pkg-up": "^2.0.0",
+				"resolve": "^1.12.0"
+			},
+			"dependencies": {
+				"doctrine": {
+					"version": "1.5.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"isarray": "^1.0.0"
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"strip-bom": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"dev": true,
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"dev": true,
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"dev": true
+				},
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"dev": true
+				},
+				"path-type": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+					"dev": true,
+					"requires": {
+						"pify": "^2.0.0"
+					}
+				},
+				"read-pkg": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "^2.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^2.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+					"dev": true,
+					"requires": {
+						"find-up": "^2.0.0",
+						"read-pkg": "^2.0.0"
+					}
+				},
+				"resolve": {
+					"version": "1.17.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+					"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+					"dev": true,
+					"requires": {
+						"path-parse": "^1.0.6"
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+					"dev": true
+				}
+			}
 		},
 		"eslint-scope": {
 			"version": "5.0.0",
@@ -1290,18 +1604,18 @@
 			"dev": true
 		},
 		"esquery": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.2.1.tgz",
-			"integrity": "sha512-/IcAXa9GWOX9BUIb/Tz2QrrAWFWzWGrFIeLeMRwtiuwg9qTFhSYemsi9DixwrFFqVbhBZ47vGcxEnu5mbPqbig==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+			"integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
 			"dev": true,
 			"requires": {
-				"estraverse": "^5.0.0"
+				"estraverse": "^5.1.0"
 			},
 			"dependencies": {
 				"estraverse": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.0.0.tgz",
-					"integrity": "sha512-j3acdrMzqrxmJTNj5dbr1YbjacrYgAxVMeF0gK16E3j494mOe7xygM/ZLIguEQ0ETwAg2hlJCtHRGav+y0Ny5A==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
+					"integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==",
 					"dev": true
 				}
 			}
@@ -2533,41 +2847,13 @@
 				}
 			}
 		},
-		"grunt-contrib-concat": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-1.0.1.tgz",
-			"integrity": "sha1-YVCYYwhOhx1+ht5IwBUlntl3Rb0=",
+		"grunt-compare-size": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/grunt-compare-size/-/grunt-compare-size-0.4.2.tgz",
+			"integrity": "sha1-0qvx082dOaFiA+EdI7cYtXV571E=",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.0.0",
-				"source-map": "^0.5.3"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
-				}
+				"lodash": "^4.11.1"
 			}
 		},
 		"grunt-contrib-uglify": {
@@ -2682,6 +2968,16 @@
 						"isexe": "^2.0.0"
 					}
 				}
+			}
+		},
+		"gzip-js": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/gzip-js/-/gzip-js-0.3.2.tgz",
+			"integrity": "sha1-IxF+/usozzhSSN7/Df+tiUg22Ws=",
+			"dev": true,
+			"requires": {
+				"crc32": ">= 0.2.2",
+				"deflate-js": ">= 0.2.2"
 			}
 		},
 		"gzip-size": {
@@ -3215,12 +3511,6 @@
 				"isobject": "^3.0.1"
 			}
 		},
-		"is-promise": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-			"dev": true
-		},
 		"is-regex": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
@@ -3243,6 +3533,12 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-running/-/is-running-2.1.0.tgz",
 			"integrity": "sha1-MKc/9cw4VOT8JUkICen1q/jeCeA=",
+			"dev": true
+		},
+		"is-string": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+			"integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
 			"dev": true
 		},
 		"is-symbol": {
@@ -3955,6 +4251,12 @@
 				}
 			}
 		},
+		"object-inspect": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+			"dev": true
+		},
 		"object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -3968,6 +4270,18 @@
 			"dev": true,
 			"requires": {
 				"isobject": "^3.0.0"
+			}
+		},
+		"object.assign": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"function-bind": "^1.1.1",
+				"has-symbols": "^1.0.0",
+				"object-keys": "^1.0.11"
 			}
 		},
 		"object.defaults": {
@@ -4011,6 +4325,71 @@
 			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
+			}
+		},
+		"object.values": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
+			"integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.1",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.17.5",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+					"integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.1.5",
+						"is-regex": "^1.0.5",
+						"object-inspect": "^1.7.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
+						"string.prototype.trimleft": "^2.1.1",
+						"string.prototype.trimright": "^2.1.1"
+					}
+				},
+				"es-to-primitive": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+					"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+					"dev": true,
+					"requires": {
+						"is-callable": "^1.1.4",
+						"is-date-object": "^1.0.1",
+						"is-symbol": "^1.0.2"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+					"dev": true
+				},
+				"is-callable": {
+					"version": "1.1.5",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+					"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+					"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+					"dev": true,
+					"requires": {
+						"has": "^1.0.3"
+					}
+				}
 			}
 		},
 		"on-finished": {
@@ -4276,6 +4655,66 @@
 			"dev": true,
 			"requires": {
 				"pinkie": "^2.0.0"
+			}
+		},
+		"pkg-dir": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+			"dev": true,
+			"requires": {
+				"find-up": "^2.1.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"dev": true,
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"dev": true,
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"dev": true
+				},
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"dev": true
+				}
 			}
 		},
 		"pkg-up": {
@@ -4637,14 +5076,29 @@
 				}
 			}
 		},
-		"run-async": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
-			"integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
+		"rollup": {
+			"version": "2.7.6",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.7.6.tgz",
+			"integrity": "sha512-AdHosxHBKyBsdtbT1/AqbWNQ87O4SSxS4N9iMwEpoCDAT6e4Du3uJSy83mp3ckgmCxly5VeXGx0WHsm21Djytg==",
 			"dev": true,
 			"requires": {
-				"is-promise": "^2.1.0"
+				"fsevents": "~2.1.2"
+			},
+			"dependencies": {
+				"fsevents": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+					"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+					"dev": true,
+					"optional": true
+				}
 			}
+		},
+		"run-async": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+			"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+			"dev": true
 		},
 		"rxjs": {
 			"version": "6.5.5",
@@ -5178,6 +5632,260 @@
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^5.0.0"
+					}
+				}
+			}
+		},
+		"string.prototype.trimend": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+			"integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.5"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.17.5",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+					"integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.1.5",
+						"is-regex": "^1.0.5",
+						"object-inspect": "^1.7.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
+						"string.prototype.trimleft": "^2.1.1",
+						"string.prototype.trimright": "^2.1.1"
+					}
+				},
+				"es-to-primitive": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+					"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+					"dev": true,
+					"requires": {
+						"is-callable": "^1.1.4",
+						"is-date-object": "^1.0.1",
+						"is-symbol": "^1.0.2"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+					"dev": true
+				},
+				"is-callable": {
+					"version": "1.1.5",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+					"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+					"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+					"dev": true,
+					"requires": {
+						"has": "^1.0.3"
+					}
+				}
+			}
+		},
+		"string.prototype.trimleft": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
+			"integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.5",
+				"string.prototype.trimstart": "^1.0.0"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.17.5",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+					"integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.1.5",
+						"is-regex": "^1.0.5",
+						"object-inspect": "^1.7.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
+						"string.prototype.trimleft": "^2.1.1",
+						"string.prototype.trimright": "^2.1.1"
+					}
+				},
+				"es-to-primitive": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+					"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+					"dev": true,
+					"requires": {
+						"is-callable": "^1.1.4",
+						"is-date-object": "^1.0.1",
+						"is-symbol": "^1.0.2"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+					"dev": true
+				},
+				"is-callable": {
+					"version": "1.1.5",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+					"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+					"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+					"dev": true,
+					"requires": {
+						"has": "^1.0.3"
+					}
+				}
+			}
+		},
+		"string.prototype.trimright": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
+			"integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.5",
+				"string.prototype.trimend": "^1.0.0"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.17.5",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+					"integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.1.5",
+						"is-regex": "^1.0.5",
+						"object-inspect": "^1.7.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
+						"string.prototype.trimleft": "^2.1.1",
+						"string.prototype.trimright": "^2.1.1"
+					}
+				},
+				"es-to-primitive": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+					"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+					"dev": true,
+					"requires": {
+						"is-callable": "^1.1.4",
+						"is-date-object": "^1.0.1",
+						"is-symbol": "^1.0.2"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+					"dev": true
+				},
+				"is-callable": {
+					"version": "1.1.5",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+					"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+					"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+					"dev": true,
+					"requires": {
+						"has": "^1.0.3"
+					}
+				}
+			}
+		},
+		"string.prototype.trimstart": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+			"integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.5"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.17.5",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+					"integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.1.5",
+						"is-regex": "^1.0.5",
+						"object-inspect": "^1.7.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
+						"string.prototype.trimleft": "^2.1.1",
+						"string.prototype.trimright": "^2.1.1"
+					}
+				},
+				"es-to-primitive": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+					"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+					"dev": true,
+					"requires": {
+						"is-callable": "^1.1.4",
+						"is-date-object": "^1.0.1",
+						"is-symbol": "^1.0.2"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+					"dev": true
+				},
+				"is-callable": {
+					"version": "1.1.5",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+					"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+					"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+					"dev": true,
+					"requires": {
+						"has": "^1.0.3"
 					}
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -28,14 +28,17 @@
 	"devDependencies": {
 		"chalk": "2.4.2",
 		"commitplease": "3.2.0",
-		"eslint-config-jquery": "2.0.0",
+		"eslint": "6.8.0",
+		"eslint-config-jquery": "3.0.0",
+		"eslint-plugin-import": "2.20.2",
 		"grunt": "1.0.4",
 		"grunt-cli": "1.3.2",
-		"grunt-contrib-concat": "1.0.1",
+		"grunt-compare-size": "0.4.2",
 		"grunt-contrib-uglify": "4.0.1",
 		"grunt-contrib-watch": "1.1.0",
 		"grunt-eslint": "22.0.0",
 		"grunt-karma": "3.0.2",
+		"gzip-js": "0.3.2",
 		"jquery": "3.5.0",
 		"karma": "4.1.0",
 		"karma-browserstack-launcher": "1.5.1",
@@ -44,6 +47,7 @@
 		"karma-qunit": "3.1.2",
 		"load-grunt-tasks": "5.0.0",
 		"qunit": "2.9.2",
+		"rollup": "2.7.6",
 		"testswarm": "1.1.0"
 	},
 	"keywords": [

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -3,29 +3,49 @@
 
 	"extends": "../.eslintrc-browser.json",
 
+	"parserOptions": {
+		"ecmaVersion": 2015,
+		"sourceType": "module"
+	},
+
+
+	"plugins": [ "import" ],
+
 	"rules": {
-		// Strict mode is only enabled in the built file.
-		"strict": "off"
+		"import/extensions": [ "error", "always" ],
+		"import/no-cycle": "error"
 	},
 
 	"globals": {
-		"Proxy": true,
-		"Reflect": true,
-
-		"jQuery": true,
-		"migrateWarn": true,
-		"migrateWarnFunc": true,
-		"migrateWarnProp": true,
-		"jQueryVersionSince": true,
-
-		"noGlobal": true
+		"jQuery": false
 	},
 
 	"overrides": [
 		{
 			"files": "wrapper.js",
+			"parserOptions": {
+				"ecmaVersion": 5,
+				"sourceType": "script"
+			},
+			"rules": {
+				"no-unused-vars": "off"
+			},
 			"globals": {
-				"jQuery": false
+				"jQuery": false,
+				"module": true,
+				"define": false
+			}
+		},
+
+		{
+			"files": "css.js",
+			"globals": {
+
+				// Defining Proxy & Reflect globally would create a danger
+				// of using it unguarded in another place, it seems safer
+				// to define it only for this module.
+				"Proxy": false,
+				"Reflect": false
 			}
 		}
 	]

--- a/src/jquery/ajax.js
+++ b/src/jquery/ajax.js
@@ -1,3 +1,4 @@
+import { migrateWarnFunc } from "../main.js";
 
 var oldAjax = jQuery.ajax;
 

--- a/src/jquery/attributes.js
+++ b/src/jquery/attributes.js
@@ -1,3 +1,4 @@
+import { migrateWarn } from "../main.js";
 
 var oldRemoveAttr = jQuery.fn.removeAttr,
 	oldToggleClass = jQuery.fn.toggleClass,

--- a/src/jquery/core.js
+++ b/src/jquery/core.js
@@ -1,3 +1,5 @@
+import { jQueryVersionSince } from "../compareVersions.js";
+import { migrateWarn, migrateWarnFunc, migrateWarnProp } from "../main.js";
 
 var findProp,
 	class2type = {},

--- a/src/jquery/css.js
+++ b/src/jquery/css.js
@@ -1,3 +1,6 @@
+import { jQueryVersionSince } from "../compareVersions.js";
+import { migrateWarn } from "../main.js";
+import { camelCase } from "../utils.js";
 
 var oldFnCss,
 	internalSwapCall = false,
@@ -25,12 +28,6 @@ var oldFnCss,
 	//         \--------------+-|       |-+---|          |---/
 	//                           \ Max /       \ Height /
 	rautoPx = /^(?:Border(?:Top|Right|Bottom|Left)?(?:Width|)|(?:Margin|Padding)?(?:Top|Right|Bottom|Left)?|(?:Min|Max)?(?:Width|Height))$/;
-
-function camelCaseString( string ) {
-	return string.replace( /-([a-z])/g, function( _, letter ) {
-		return letter.toUpperCase();
-	} );
-}
 
 // If this version of jQuery has .swap(), don't false-alarm on internal uses
 if ( jQuery.swap ) {
@@ -108,7 +105,7 @@ jQuery.fn.css = function( name, value ) {
 			jQuery.fn.css.call( origThis, n, v );
 		} );
 	}
-	if ( typeof value === "number" && !isAutoPx( camelCaseString( name ) ) ) {
+	if ( typeof value === "number" && !isAutoPx( camelCase( name ) ) ) {
 		migrateWarn( "Use of number-typed values is deprecated in jQuery.fn.css" );
 	}
 

--- a/src/jquery/data.js
+++ b/src/jquery/data.js
@@ -1,10 +1,7 @@
-var oldData = jQuery.data,
+import { migrateWarn } from "../main.js";
+import { camelCase } from "../utils.js";
 
-	camelCase = function( string ) {
-		return string.replace( /-([a-z])/g, function( _, letter ) {
-			return letter.toUpperCase();
-		} );
-	};
+var oldData = jQuery.data;
 
 jQuery.data = function( elem, name, value ) {
 	var curData, sameKeys, key;

--- a/src/jquery/deferred.js
+++ b/src/jquery/deferred.js
@@ -1,3 +1,4 @@
+import { migrateWarn } from "../main.js";
 
 var oldDeferred = jQuery.Deferred,
 	tuples = [

--- a/src/jquery/effects.js
+++ b/src/jquery/effects.js
@@ -1,3 +1,5 @@
+import { migrateWarn } from "../main.js";
+
 var intervalValue, intervalMsg,
 	oldTweenRun = jQuery.Tween.prototype.run,
 	linearEasing = function( pct ) {

--- a/src/jquery/event.js
+++ b/src/jquery/event.js
@@ -1,3 +1,5 @@
+import { migrateWarn, migrateWarnProp } from "../main.js";
+
 var oldLoad = jQuery.fn.load,
 	oldEventAdd = jQuery.event.add,
 	originalFix = jQuery.event.fix;

--- a/src/jquery/manipulation.js
+++ b/src/jquery/manipulation.js
@@ -1,3 +1,5 @@
+import { migrateWarn } from "../main.js";
+
 var rxhtmlTag = /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([a-z][^\/\0>\x20\t\r\n\f]*)[^>]*)\/>/gi,
 	origHtmlPrefilter = jQuery.htmlPrefilter,
 	makeMarkup = function( html ) {

--- a/src/jquery/offset.js
+++ b/src/jquery/offset.js
@@ -1,3 +1,4 @@
+import { migrateWarn } from "../main.js";
 
 var oldOffset = jQuery.fn.offset;
 

--- a/src/jquery/serialize.js
+++ b/src/jquery/serialize.js
@@ -1,3 +1,4 @@
+import { migrateWarn } from "../main.js";
 
 var oldParam = jQuery.param;
 

--- a/src/jquery/traversing.js
+++ b/src/jquery/traversing.js
@@ -1,3 +1,5 @@
+import { migrateWarn } from "../main.js";
+
 var oldSelf = jQuery.fn.andSelf || jQuery.fn.addBack;
 
 jQuery.fn.andSelf = function() {

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,86 @@
+import { jQueryVersionSince } from "./compareVersions.js";
+
+( function() {
+
+	// Support: IE9 only
+	// IE9 only creates console object when dev tools are first opened
+	// IE9 console is a host object, callable but doesn't have .apply()
+	if ( !window.console || !window.console.log ) {
+		return;
+	}
+
+	// Need jQuery 3.0.0+ and no older Migrate loaded
+	if ( !jQuery || !jQueryVersionSince( "3.0.0" ) ) {
+		window.console.log( "JQMIGRATE: jQuery 3.0.0+ REQUIRED" );
+	}
+	if ( jQuery.migrateWarnings ) {
+		window.console.log( "JQMIGRATE: Migrate plugin loaded multiple times" );
+	}
+
+	// Show a message on the console so devs know we're active
+	window.console.log( "JQMIGRATE: Migrate is installed" +
+		( jQuery.migrateMute ? "" : " with logging active" ) +
+		", version " + jQuery.migrateVersion );
+
+} )();
+
+export var warnedAbout = {};
+
+// By default each warning is only reported once.
+jQuery.migrateDeduplicateWarnings = true;
+
+// List of warnings already given; public read only
+jQuery.migrateWarnings = [];
+
+// Set to false to disable traces that appear with warnings
+if ( jQuery.migrateTrace === undefined ) {
+	jQuery.migrateTrace = true;
+}
+
+// Forget any warnings we've already given; public
+jQuery.migrateReset = function() {
+	warnedAbout = {};
+	jQuery.migrateWarnings.length = 0;
+};
+
+export function migrateWarn( msg ) {
+	var console = window.console;
+	if ( !jQuery.migrateDeduplicateWarnings || !warnedAbout[ msg ] ) {
+		warnedAbout[ msg ] = true;
+		jQuery.migrateWarnings.push( msg );
+		if ( console && console.warn && !jQuery.migrateMute ) {
+			console.warn( "JQMIGRATE: " + msg );
+			if ( jQuery.migrateTrace && console.trace ) {
+				console.trace();
+			}
+		}
+	}
+}
+
+export function migrateWarnProp( obj, prop, value, msg ) {
+	Object.defineProperty( obj, prop, {
+		configurable: true,
+		enumerable: true,
+		get: function() {
+			migrateWarn( msg );
+			return value;
+		},
+		set: function( newValue ) {
+			migrateWarn( msg );
+			value = newValue;
+		}
+	} );
+}
+
+export function migrateWarnFunc( obj, prop, newFunc, msg ) {
+	obj[ prop ] = function() {
+		migrateWarn( msg );
+		return newFunc.apply( this, arguments );
+	};
+}
+
+if ( window.document.compatMode === "BackCompat" ) {
+
+	// JQuery has never supported or tested Quirks Mode
+	migrateWarn( "jQuery is not compatible with Quirks Mode" );
+}

--- a/src/migrate.js
+++ b/src/migrate.js
@@ -1,86 +1,15 @@
-/* exported migrateWarn, migrateWarnFunc, migrateWarnProp */
-
-( function() {
-
-	// Support: IE9 only
-	// IE9 only creates console object when dev tools are first opened
-	// IE9 console is a host object, callable but doesn't have .apply()
-	if ( !window.console || !window.console.log ) {
-		return;
-	}
-
-	// Need jQuery 3.0.0+ and no older Migrate loaded
-	if ( !jQuery || !jQueryVersionSince( "3.0.0" ) ) {
-		window.console.log( "JQMIGRATE: jQuery 3.0.0+ REQUIRED" );
-	}
-	if ( jQuery.migrateWarnings ) {
-		window.console.log( "JQMIGRATE: Migrate plugin loaded multiple times" );
-	}
-
-	// Show a message on the console so devs know we're active
-	window.console.log( "JQMIGRATE: Migrate is installed" +
-		( jQuery.migrateMute ? "" : " with logging active" ) +
-		", version " + jQuery.migrateVersion );
-
-} )();
-
-var warnedAbout = {};
-
-// By default each warning is only reported once.
-jQuery.migrateDeduplicateWarnings = true;
-
-// List of warnings already given; public read only
-jQuery.migrateWarnings = [];
-
-// Set to false to disable traces that appear with warnings
-if ( jQuery.migrateTrace === undefined ) {
-	jQuery.migrateTrace = true;
-}
-
-// Forget any warnings we've already given; public
-jQuery.migrateReset = function() {
-	warnedAbout = {};
-	jQuery.migrateWarnings.length = 0;
-};
-
-function migrateWarn( msg ) {
-	var console = window.console;
-	if ( !jQuery.migrateDeduplicateWarnings || !warnedAbout[ msg ] ) {
-		warnedAbout[ msg ] = true;
-		jQuery.migrateWarnings.push( msg );
-		if ( console && console.warn && !jQuery.migrateMute ) {
-			console.warn( "JQMIGRATE: " + msg );
-			if ( jQuery.migrateTrace && console.trace ) {
-				console.trace();
-			}
-		}
-	}
-}
-
-function migrateWarnProp( obj, prop, value, msg ) {
-	Object.defineProperty( obj, prop, {
-		configurable: true,
-		enumerable: true,
-		get: function() {
-			migrateWarn( msg );
-			return value;
-		},
-		set: function( newValue ) {
-			migrateWarn( msg );
-			value = newValue;
-		}
-	} );
-}
-
-function migrateWarnFunc( obj, prop, newFunc, msg ) {
-	obj[ prop ] = function() {
-		migrateWarn( msg );
-		return newFunc.apply( this, arguments );
-	};
-}
-
-if ( window.document.compatMode === "BackCompat" ) {
-
-	// JQuery has never supported or tested Quirks Mode
-	migrateWarn( "jQuery is not compatible with Quirks Mode" );
-}
+import "./version.js";
+import "./compareVersions.js";
+import "./main.js";
+import "./jquery/core.js";
+import "./jquery/ajax.js";
+import "./jquery/attributes.js";
+import "./jquery/css.js";
+import "./jquery/data.js";
+import "./jquery/effects.js";
+import "./jquery/event.js";
+import "./jquery/manipulation.js";
+import "./jquery/offset.js";
+import "./jquery/serialize.js";
+import "./jquery/traversing.js";
+import "./jquery/deferred.js";

--- a/src/outro.js
+++ b/src/outro.js
@@ -1,2 +1,0 @@
-return jQuery;
-} );

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,5 @@
+export function camelCase( string ) {
+	return string.replace( /-([a-z])/g, function( _, letter ) {
+		return letter.toUpperCase();
+	} );
+}

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -1,4 +1,10 @@
-;( function( factory ) {
+/*!
+ * jQuery Migrate - v@VERSION - @DATE
+ * Copyright OpenJS Foundation and other contributors
+ */
+( function( factory ) {
+	"use strict";
+
 	if ( typeof define === "function" && define.amd ) {
 
 		// AMD. Register as an anonymous module.
@@ -17,3 +23,9 @@
 	}
 } )( function( jQuery, window ) {
 "use strict";
+
+// @CODE
+// build.js inserts compiled jQuery here
+
+return jQuery;
+} );

--- a/test/data/compareVersions.js
+++ b/test/data/compareVersions.js
@@ -16,6 +16,6 @@ function compareVersions( v1, v2 ) {
 	return 0;
 }
 
-export function jQueryVersionSince( version ) {
+function jQueryVersionSince( version ) {
 	return compareVersions( jQuery.fn.jquery, version ) >= 0;
 }

--- a/test/index.html
+++ b/test/index.html
@@ -23,7 +23,7 @@
 	</script>
 
 	<!-- Version comparisons -->
-	<script src="../src/compareVersions.js"></script>
+	<script src="data/compareVersions.js"></script>
 
 	<!-- Unit test files -->
 	<script src="migrate.js"></script>


### PR DESCRIPTION
The new Rollup-based build system is a very simplified version of the jQuery
one, without all the complex custom compilation aspects.

Apart from that, `grunt-compare-size` was added. While we don't care about size in Migrate to the same level as in Core, it's still good to see the impact of some changes, especially when refactoring existing code.

-1 byte compared to `master` - while the new `"use strict"` adds 1 byte, deduplication of two identical `camelCase` functions reduces the size.