### PR TITLE
Core: Support the jQuery slim build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,6 +7,29 @@ module.exports = function( grunt ) {
 	const gzip = require( "gzip-js" );
 	const isTravis = process.env.TRAVIS;
 
+	const karmaFilesExceptJQuery = [
+		"dist/jquery-migrate.min.js",
+		"test/data/compareVersions.js",
+
+		"test/testinit.js",
+		"test/migrate.js",
+		"test/core.js",
+		"test/ajax.js",
+		"test/attributes.js",
+		"test/css.js",
+		"test/data.js",
+		"test/deferred.js",
+		"test/effects.js",
+		"test/event.js",
+		"test/manipulation.js",
+		"test/offset.js",
+		"test/serialize.js",
+		"test/traversing.js",
+
+		{ pattern: "dist/jquery-migrate.js", included: false, served: true },
+		{ pattern: "test/**/*.@(js|css|jpg|html|xml)", included: false, served: true }
+	];
+
 	// Project configuration.
 	grunt.initConfig( {
 		pkg: grunt.file.readJSON( "package.json" ),
@@ -24,17 +47,27 @@ module.exports = function( grunt ) {
 		tests: {
 			jquery: [
 				"dev+git",
-				"min+git.min"
+				"min+git.min",
+				"dev+git.slim",
+				"min+git.slim.min"
 			],
 			"jquery-3": [
 				"dev+3.x-git",
 				"min+3.x-git.min",
+				"dev+3.x-git.slim",
+				"min+3.x-git.slim.min",
 				"dev+3.5.0",
+				"dev+3.5.0.slim",
 				"dev+3.4.1",
+				"dev+3.4.1.slim",
 				"dev+3.3.1",
+				"dev+3.3.1.slim",
 				"dev+3.2.1",
+				"dev+3.2.1.slim",
 				"dev+3.1.1",
-				"dev+3.0.0"
+				"dev+3.1.1.slim",
+				"dev+3.0.0",
+				"dev+3.0.0.slim"
 			]
 		},
 		banners: {
@@ -123,26 +156,7 @@ module.exports = function( grunt ) {
 				frameworks: [ "qunit" ],
 				files: [
 					"https://code.jquery.com/jquery-3.x-git.min.js",
-					"dist/jquery-migrate.min.js",
-					"test/data/compareVersions.js",
-
-					"test/testinit.js",
-					"test/migrate.js",
-					"test/core.js",
-					"test/ajax.js",
-					"test/attributes.js",
-					"test/css.js",
-					"test/data.js",
-					"test/deferred.js",
-					"test/effects.js",
-					"test/event.js",
-					"test/manipulation.js",
-					"test/offset.js",
-					"test/serialize.js",
-					"test/traversing.js",
-
-					{ pattern: "dist/jquery-migrate.js", included: false, served: true },
-					{ pattern: "test/**/*.@(js|css|jpg|html|xml)", included: false, served: true }
+					...karmaFilesExceptJQuery
 				],
 				client: {
 					clearContext: false,
@@ -161,6 +175,19 @@ module.exports = function( grunt ) {
 
 				// The Chrome sandbox doesn't work on Travis.
 				browsers: [ isTravis ? "ChromeHeadlessNoSandbox" : "ChromeHeadless" ]
+			},
+
+			"jquery-slim": {
+
+				// The Chrome sandbox doesn't work on Travis.
+				browsers: [ isTravis ? "ChromeHeadlessNoSandbox" : "ChromeHeadless" ],
+
+				options: {
+					files: [
+						"https://code.jquery.com/jquery-3.x-git.slim.min.js",
+						...karmaFilesExceptJQuery
+					]
+				}
 			},
 
 			// To debug tests with Karma:
@@ -191,7 +218,10 @@ module.exports = function( grunt ) {
 	grunt.loadTasks( "build/tasks" );
 
 	// Just an alias
-	grunt.registerTask( "test", [ "karma:main" ] );
+	grunt.registerTask( "test", [
+		"karma:main",
+		"karma:jquery-slim"
+	] );
 
 	grunt.registerTask( "lint", [
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4145,6 +4145,12 @@
 				"to-regex": "^3.0.1"
 			}
 		},
+		"native-promise-only": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+			"integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
+			"dev": true
+		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 		"karma-firefox-launcher": "1.1.0",
 		"karma-qunit": "3.1.2",
 		"load-grunt-tasks": "5.0.0",
+		"native-promise-only": "0.8.1",
 		"qunit": "2.9.2",
 		"rollup": "2.7.6",
 		"testswarm": "1.1.0"

--- a/src/jquery/ajax.js
+++ b/src/jquery/ajax.js
@@ -1,5 +1,8 @@
 import { migrateWarnFunc } from "../main.js";
 
+// Support jQuery slim which excludes the ajax module
+if ( jQuery.ajax ) {
+
 var oldAjax = jQuery.ajax;
 
 jQuery.ajax = function( ) {
@@ -17,3 +20,5 @@ jQuery.ajax = function( ) {
 
 	return jQXHR;
 };
+
+}

--- a/src/jquery/deferred.js
+++ b/src/jquery/deferred.js
@@ -1,5 +1,8 @@
 import { migrateWarn } from "../main.js";
 
+// Support jQuery slim which excludes the deferred module in jQuery 4.0+
+if ( jQuery.Deferred ) {
+
 var oldDeferred = jQuery.Deferred,
 	tuples = [
 
@@ -57,3 +60,5 @@ jQuery.Deferred = function( func ) {
 
 // Preserve handler of uncaught exceptions in promise chains
 jQuery.Deferred.exceptionHook = oldDeferred.exceptionHook;
+
+}

--- a/src/jquery/effects.js
+++ b/src/jquery/effects.js
@@ -1,5 +1,8 @@
 import { migrateWarn } from "../main.js";
 
+// Support jQuery slim which excludes the effects module
+if ( jQuery.fx ) {
+
 var intervalValue, intervalMsg,
 	oldTweenRun = jQuery.Tween.prototype.run,
 	linearEasing = function( pct ) {
@@ -39,4 +42,6 @@ if ( window.requestAnimationFrame ) {
 			intervalValue = newValue;
 		}
 	} );
+}
+
 }

--- a/src/jquery/serialize.js
+++ b/src/jquery/serialize.js
@@ -1,5 +1,10 @@
 import { migrateWarn } from "../main.js";
 
+// Support jQuery slim which excludes the ajax module
+// The jQuery.param patch is about respecting `jQuery.ajaxSettings.traditional`
+// so it doesn't make sense for the slim build.
+if ( jQuery.ajax ) {
+
 var oldParam = jQuery.param;
 
 jQuery.param = function( data, traditional ) {
@@ -13,3 +18,5 @@ jQuery.param = function( data, traditional ) {
 
 	return oldParam.call( this, data, traditional );
 };
+
+}

--- a/test/ajax.js
+++ b/test/ajax.js
@@ -1,3 +1,6 @@
+// Support jQuery slim which excludes the ajax module
+if ( jQuery.ajax ) {
+
 QUnit.module( "ajax" );
 
 QUnit.test( "jQuery.ajax() deprecations on jqXHR", function( assert ) {
@@ -23,3 +26,5 @@ QUnit.test( "jQuery.ajax() deprecations on jqXHR", function( assert ) {
 	} );
 
 } );
+
+}

--- a/test/deferred.js
+++ b/test/deferred.js
@@ -1,3 +1,5 @@
+// Support jQuery slim which excludes the deferred module in jQuery 4.0+
+if ( jQuery.Deferred ) {
 
 QUnit.module( "deferred" );
 
@@ -155,3 +157,5 @@ QUnit.test( "[PIPE ONLY] jQuery.Deferred.pipe - context", function( assert ) {
 		done.pop().call();
 	} );
 } );
+
+}

--- a/test/effects.js
+++ b/test/effects.js
@@ -1,3 +1,6 @@
+// Support jQuery slim which excludes the effects module
+if ( jQuery.fx ) {
+
 QUnit.module( "effects" );
 
 QUnit.test( "jQuery.easing", function( assert ) {
@@ -83,3 +86,5 @@ QUnit.test( "jQuery.fx.interval - user change", function( assert ) {
 
 	jQuery.fx.interval = oldInterval;
 } );
+
+}

--- a/test/event-lateload.html
+++ b/test/event-lateload.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>jQuery Migrate late load event binding test</title>
+	<script src="../node_modules/native-promise-only/lib/npo.src.js"></script>
 
 	<!-- Load a jQuery and jquery-migrate plugin file based on URL -->
 	<script src="testinit.js"></script>
@@ -15,14 +16,17 @@
 		TestManager.loadProject( "jquery-migrate", "dev", true );
 	</script>
 	<script>
-		var loaded = jQuery.Deferred();
+		var resolve,
+			loaded = new Promise( function ( _resolve ) {
+				resolve = _resolve;
+			} );
 
 		// No warning here, document isn't yet loaded
 		jQuery( window ).on( "load", function() {
-			loaded.resolve();
+			resolve();
 		});
 
-		jQuery.when( jQuery.ready, loaded ).then( function() {
+		Promise.all( [ jQuery.ready, loaded ] ).then( function() {
 
 			// This .on() call should warn
 			jQuery( window ).on( "load", jQuery.noop );

--- a/test/event.js
+++ b/test/event.js
@@ -17,7 +17,7 @@ QUnit.test( "error() event method", function( assert ) {
 } );
 
 QUnit.test( "load() and unload() event methods", function( assert ) {
-	assert.expect( 5 );
+	assert.expect( jQuery.ajax ? 5 : 4 );
 
 	expectWarning( assert, "jQuery.fn.load()", function() {
 		jQuery( "<img />" )
@@ -41,15 +41,17 @@ QUnit.test( "load() and unload() event methods", function( assert ) {
 			.remove();
 	} );
 
-	expectNoWarning( assert, "ajax load", function() {
-		var start = assert.async();
-		jQuery( "<div id=load138></div>" )
-			.appendTo( "#qunit-fixture" )
-			.load( "not-found.file", function() {
-				jQuery( "#load138" ).remove();
-				start();
-			} );
-	} );
+	if ( jQuery.ajax ) {
+		expectNoWarning( assert, "ajax load", function() {
+			var start = assert.async();
+			jQuery( "<div id=load138></div>" )
+				.appendTo( "#qunit-fixture" )
+				.load( "not-found.file", function() {
+					jQuery( "#load138" ).remove();
+					start();
+				} );
+		} );
+	}
 } );
 
 QUnit.test( ".bind() and .unbind()", function( assert ) {

--- a/test/serialize.js
+++ b/test/serialize.js
@@ -1,6 +1,11 @@
 
 QUnit.module( "serialize" );
 
+// Support jQuery slim which excludes the ajax module
+// The jQuery.param patch is about respecting `jQuery.ajaxSettings.traditional`
+// so it doesn't make sense for the slim build.
+if ( jQuery.ajax ) {
+
 QUnit.test( "jQuery.param( x, traditional)", function( assert ) {
 	assert.expect( 12 );
 
@@ -49,3 +54,5 @@ QUnit.test( "jQuery.param( x, traditional)", function( assert ) {
 
 	jQuery.ajaxSettings.traditional = savedTraditional;
 } );
+
+}

--- a/test/testinit.js
+++ b/test/testinit.js
@@ -157,11 +157,14 @@ TestManager = {
 TestManager.init( {
 	"jquery": {
 		urlTag: "jquery",
-		choices: "dev,min,git,git.min,3.x-git,3.x-git.min,3.5.0,3.4.1,3.3.1,3.2.1,3.1.1,3.0.0"
+		choices: "dev,min,git,git.min,git.slim,git.slim.min," +
+			"3.x-git,3.x-git.min,3.x-git.slim,3.x-git.slim.min," +
+			"3.5.0,3.5.0.slim,3.4.1,3.4.1.slim," +
+			"3.3.1,3.3.1.slim,3.2.1,3.2.1.slim,3.1.1,3.1.1.slim,3.0.0,3.0.0.slim"
 	},
 	"jquery-migrate": {
 		urlTag: "plugin",
-		choices: "dev,min,raw,git,3.0.1,3.0.0"
+		choices: "dev,min,raw,git,3.2.0,3.1.0,3.0.1,3.0.0"
 	}
 } );
 


### PR DESCRIPTION
While it'd be hard for Migrate to support all the possible jQuery builds,
the slim build is special as it's officially maintained by the jQuery team,
published to npm & uploaded to CDNs.

This commit adds support for the jQuery slim build in jQuery 3.0.0 & newer.
The slim build is now tested next to the regular one.

Fixes #345