### PR TITLE
CSS: Don't warn for number values when prop in jQuery.cssNumber

### DIFF
--- a/src/jquery/css.js
+++ b/src/jquery/css.js
@@ -99,14 +99,19 @@ function isAutoPx( prop ) {
 oldFnCss = jQuery.fn.css;
 
 jQuery.fn.css = function( name, value ) {
-	var origThis = this;
+	var camelName,
+		origThis = this;
 	if ( typeof name !== "string" ) {
 		jQuery.each( name, function( n, v ) {
 			jQuery.fn.css.call( origThis, n, v );
 		} );
 	}
-	if ( typeof value === "number" && !isAutoPx( camelCase( name ) ) ) {
-		migrateWarn( "Use of number-typed values is deprecated in jQuery.fn.css" );
+	if ( typeof value === "number" ) {
+		camelName = camelCase( name );
+		if ( !isAutoPx( camelName ) && !jQuery.cssNumber[ camelName ] ) {
+			migrateWarn( "Number-typed values are deprecated for jQuery.fn.css( \"" +
+				name + "\", value )" );
+		}
 	}
 
 	return oldFnCss.apply( this, arguments );

--- a/test/css.js
+++ b/test/css.js
@@ -45,40 +45,41 @@ QUnit[ ( jQueryVersionSince( "3.4.0" ) && typeof Proxy !== "undefined" ) ? "test
 } );
 
 QUnit.test( "jQuery.css with numbers", function( assert ) {
-	assert.expect( 5 );
+	var jQuery3OrOlder = compareVersions( jQuery.fn.jquery, "4.0.0" ) < 0,
+		whitelist = [
+			"margin",
+			"marginTop",
+			"marginRight",
+			"marginBottom",
+			"marginLeft",
+			"padding",
+			"paddingTop",
+			"paddingRight",
+			"paddingBottom",
+			"paddingLeft",
+			"top",
+			"right",
+			"bottom",
+			"left",
+			"width",
+			"height",
+			"minWidth",
+			"minHeight",
+			"maxWidth",
+			"maxHeight",
+			"border",
+			"borderWidth",
+			"borderTop",
+			"borderTopWidth",
+			"borderRight",
+			"borderRightWidth",
+			"borderBottom",
+			"borderBottomWidth",
+			"borderLeft",
+			"borderLeftWidth"
+		];
 
-	var whitelist = [
-		"margin",
-		"marginTop",
-		"marginRight",
-		"marginBottom",
-		"marginLeft",
-		"padding",
-		"paddingTop",
-		"paddingRight",
-		"paddingBottom",
-		"paddingLeft",
-		"top",
-		"right",
-		"bottom",
-		"left",
-		"width",
-		"height",
-		"minWidth",
-		"minHeight",
-		"maxWidth",
-		"maxHeight",
-		"border",
-		"borderWidth",
-		"borderTop",
-		"borderTopWidth",
-		"borderRight",
-		"borderRightWidth",
-		"borderBottom",
-		"borderBottomWidth",
-		"borderLeft",
-		"borderLeftWidth"
-	];
+	assert.expect( jQuery3OrOlder ?  7 : 6 );
 
 	function kebabCase( string ) {
 		return string.replace( /[A-Z]/g, function( match ) {
@@ -87,26 +88,26 @@ QUnit.test( "jQuery.css with numbers", function( assert ) {
 	}
 
 	expectWarning( assert, "Number value direct", function() {
-		jQuery( "<div />" ).css( "line-height", 10 );
+		jQuery( "<div />" ).css( "fake-property", 10 );
 	} );
 
 	expectWarning( assert, "Number in an object", 1, function() {
 		jQuery( "<div />" ).css( {
 			"width": 14,
 			"height": "10px",
-			"line-height": 2
+			"fake-property": 2
 		} );
 	} );
 
 	expectNoWarning( assert, "String value direct", function() {
-		jQuery( "<div />" ).css( "line-height", "10px" );
+		jQuery( "<div />" ).css( "fake-property", "10px" );
 	} );
 
 	expectNoWarning( assert, "String in an object", function() {
 		jQuery( "<div />" ).css( {
 			"width": "14em",
 			"height": "10px",
-			"line-height": "2"
+			"fake-property": "2"
 		} );
 	} );
 
@@ -115,6 +116,19 @@ QUnit.test( "jQuery.css with numbers", function( assert ) {
 			jQuery( "<div />" ).css( prop, 1 );
 			jQuery( "<div />" ).css( kebabCase( prop ), 1 );
 		} );
+	} );
+
+	expectNoWarning( assert, "Props from jQuery.cssNumber", function() {
+		var prop,
+			assertionFired = false;
+		for ( prop in jQuery.cssNumber ) {
+			assertionFired = true;
+			jQuery( "<div />" ).css( prop, 1 );
+			jQuery( "<div />" ).css( kebabCase( prop ), 1 );
+		}
+		if ( jQuery3OrOlder ) {
+			assert.strictEqual( assertionFired, true, "jQuery.cssNumber property was accessed" );
+		}
 	} );
 
 } );


### PR DESCRIPTION
Relying on numerical values for most CSS properties having `"px"` auto-appended
when set via `.css( prop, value )` is deprecated. So far, Migrate was warning
for number values for all CSS properties with the exception of the ones to which
jQuery 4.x will still auto-append `"px"`. However, if the used jQuery version
contains the property as a key in `jQuery.cssNumber`, it will already skip
the `"px"` auto-appending behavior, exactly as jQuery 4.x will. This commit
removes a warning in such cases.

This change will help jQuery UI from not triggering Migrate warnings.