### PR TITLE
Build: Remove an obsolete comment

### DIFF
--- a/build/tasks/testswarm.js
+++ b/build/tasks/testswarm.js
@@ -37,7 +37,6 @@ module.exports = function( grunt ) {
 				pluginjQuery[ 0 ] + "&jquery=" + pluginjQuery[ 1 ];
 		} );
 
-		// TODO: create separate job for git so we can do different browsersets
 		testswarm.createClient( {
 			url: config.swarmUrl
 		} )


### PR DESCRIPTION
We already use separate browser sets to be able to test with jQuery 3.x & 4.x.
The comment that we need separate jobs no longer applies - we already have them.