### PR TITLE
Build: Update the version in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "jquery-migrate",
-	"version": "3.2.1-pre",
+	"version": "3.3.1-pre",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
So far, only the one in package.json got updated. That means
each `npm install` leaves the repository in a dirty state
by updating that field.