### PR TITLE
Build: Remove the migrateMute setter in PhantomJS in tests

### DIFF
--- a/test/iframeTest.js
+++ b/test/iframeTest.js
@@ -3,12 +3,6 @@
  * Load this file immediately after jQuery, before jQuery Migrate
  */
 
-// Don't spew on in the console window when we build
-// Warning messages are available to parent test in jQuery.migrateWarnings
-if ( navigator.userAgent.indexOf( "PhantomJS" ) >= 0 ) {
-	jQuery.migrateMute = true;
-}
-
 // Support: IE9 only (no console at times)
 if ( !window.console ) {
 	window.console = {};

--- a/test/migrate.js
+++ b/test/migrate.js
@@ -1,10 +1,5 @@
 /* exported expectWarning, expectNoWarning */
 
-// Don't spew on in the console window when we build
-if ( navigator.userAgent.indexOf( "PhantomJS" ) >= 0 ) {
-	jQuery.migrateMute = true;
-}
-
 function expectWarning( assert, name, expected, fn ) {
 	if ( !fn ) {
 		fn = expected;


### PR DESCRIPTION
We no longer test on PhantomJS but on Chrome Headless instead so disabling the
warning logs didn't have any effect. On the other hand, it looks like console
output from Chrome Headless is already silenced.