### PR TITLE
Tests: Fix offset tests in jQuery 3.0-3.1

### DIFF
--- a/test/offset.js
+++ b/test/offset.js
@@ -2,7 +2,7 @@
 QUnit.module( "offset" );
 
 QUnit.test( ".offset()", function( assert ) {
-	assert.expect( 20 );
+	assert.expect( 21 );
 
 	var bogus = { top: 0, left: 0 };
 
@@ -40,7 +40,8 @@ QUnit.test( ".offset()", function( assert ) {
 
 	expectWarning( assert, ".offset() as setter on disconnected node", 2,
 			function() {
-		var $elemInitial = jQuery( "<div />" )
+		var offset,
+			$elemInitial = jQuery( "<div />" )
 				.css( "position", "fixed" ),
 			$elem = $elemInitial
 				.offset( { top: 42, left: 99 } );
@@ -49,7 +50,9 @@ QUnit.test( ".offset()", function( assert ) {
 			".offset() returns a proper jQuery object" );
 
 		$elem.appendTo( "#qunit-fixture" );
-		assert.deepEqual( $elem.offset(), { top: 42, left: 99 } );
+		offset = $elem.offset();
+		assert.strictEqual( offset.top, 42, "proper top offset" );
+		assert.strictEqual( offset.left, 99, "proper left offset" );
 	} );
 
 	expectWarning( assert, ".offset() on empty set", 2, function() {


### PR DESCRIPTION
`.offset()` in jQuery 3.0.0-3.1.1 sometimes returns an object with more than
just `top` & `left` properties. This was fixed in jQuery 3.2.0. Since we're not
in a business of fixing older jQuery versions here, this commit updates the test
instead.

Ref jquery/jquery#3367
Ref gh-352

See the failures at http://swarm.jquery.org/job/9837.