### PR TITLE
CSS: Don't break `.css( array )`

### DIFF
--- a/src/jquery/css.js
+++ b/src/jquery/css.js
@@ -101,7 +101,7 @@ oldFnCss = jQuery.fn.css;
 jQuery.fn.css = function( name, value ) {
 	var camelName,
 		origThis = this;
-	if ( typeof name !== "string" ) {
+	if ( name && typeof name === "object" && !Array.isArray( name ) ) {
 		jQuery.each( name, function( n, v ) {
 			jQuery.fn.css.call( origThis, n, v );
 		} );

--- a/test/css.js
+++ b/test/css.js
@@ -44,6 +44,22 @@ QUnit[ ( jQueryVersionSince( "3.4.0" ) && typeof Proxy !== "undefined" ) ? "test
 	delete jQuery.cssProps.devoHat;
 } );
 
+QUnit.test( "jQuery.css with arrays", function( assert ) {
+	assert.expect( 2 );
+
+	expectNoWarning( assert, "String value direct", function() {
+		var cssValues = jQuery( "<div />" )
+			.css( {
+				lineHeight: "1",
+				fontSize: "16px"
+			} )
+			.css( [ "font-size", "lineHeight" ] );
+
+		assert.deepEqual( cssValues, { "font-size": "16px", lineHeight: "1" },
+			".css( array ) works" );
+	} );
+} );
+
 QUnit.test( "jQuery.css with numbers", function( assert ) {
 	var jQuery3OrOlder = compareVersions( jQuery.fn.jquery, "4.0.0" ) < 0,
 		whitelist = [


### PR DESCRIPTION
jQuery ~~3.3.0~~ 1.9 added support for array input to the `.css()` method; so far
Migrate was crashing with such input.

Fixes gh-357