### PR TITLE
Docs: Update jQuery.trim warning text

### DIFF
--- a/warnings.md
+++ b/warnings.md
@@ -252,7 +252,7 @@ See jQuery-ui [commit](https://github.com/jquery/jquery-ui/commit/c0093b599fcd58
 
 **Cause:** Older versions of IE & Android Browser didn't implement a method to `trim` strings so jQuery provided a cross-browser implementation. The browsers supported by jQuery 3.0 all provide a standard method for this purpose.
 
-**Solution:** Replace any calls to `jQuery.trim( text )` with `text.trim()` if you know `text` is a string; otherwise, you can replace it with `text == null ? "" : text.trim()`.
+**Solution:** Replace any calls to `jQuery.trim( text )` with `text.trim()` if you know `text` is a string; otherwise, you can replace it with `String.prototype.trim.call( text == null ? "" : text )`.
 
 ### JQMIGRATE: Use of number-typed values is deprecated in jQuery.fn.css
 


### PR DESCRIPTION
The previous replacement:
```js
text == null ? "" : text.trim()
```
didn't account for non-`null` non-string input, e.g. numbers.