### PR TITLE
Build: Update the npm testswarm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5362,9 +5362,9 @@
 			}
 		},
 		"testswarm": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/testswarm/-/testswarm-1.1.1.tgz",
-			"integrity": "sha512-hBbOiH9gebR+4Iw7G7oKP030uKDn4BbSg1JtH3KjYSI30rV/2T9O9JFMuofNX7y7EkkVmlkxdGLLThzvC5S/Fw==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/testswarm/-/testswarm-1.1.2.tgz",
+			"integrity": "sha512-qQ3+ryHoaZCVwRHbPgQQ5qRPOlmJfYwq8Upx8IP6VYHPYQBnk7SSN3lkJkqE1M3lm2VywVre98Z5SCw1WKFVEQ==",
 			"dev": true,
 			"requires": {
 				"request": "~2.88.0"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"native-promise-only": "0.8.1",
 		"qunit": "2.10.0",
 		"rollup": "2.15.0",
-		"testswarm": "1.1.1"
+		"testswarm": "1.1.2"
 	},
 	"keywords": [
 		"jquery",


### PR DESCRIPTION
The previous version, 1.1.1 had a critical bug that makes it not submit
`runUrls` properly. It is fixed in 1.1.2.

Ref gh-365
Ref jzaefferer/node-testswarm#17