### PR TITLE
Core: Warn against jQuery.isArray in jQuery >=3.2, not 3.3 

### DIFF
--- a/src/jquery/core.js
+++ b/src/jquery/core.js
@@ -106,6 +106,10 @@ if ( jQueryVersionSince( "3.2.0" ) ) {
 		return elem.nodeName && elem.nodeName.toLowerCase() === name.toLowerCase();
 	},
 	"jQuery.nodeName is deprecated" );
+
+	migrateWarnFunc( jQuery, "isArray", Array.isArray,
+		"jQuery.isArray is deprecated; use Array.isArray"
+	);
 }
 
 if ( jQueryVersionSince( "3.3.0" ) ) {
@@ -156,9 +160,5 @@ if ( jQueryVersionSince( "3.3.0" ) ) {
 			return obj != null && obj === obj.window;
 		},
 		"jQuery.isWindow() is deprecated"
-	);
-
-	migrateWarnFunc( jQuery, "isArray", Array.isArray,
-		"jQuery.isArray is deprecated; use Array.isArray"
 	);
 }

--- a/test/core.js
+++ b/test/core.js
@@ -478,7 +478,7 @@ QUnit[ jQueryVersionSince( "3.3.0" ) ? "test" : "skip" ]( "jQuery.type (warn)", 
 
 } );
 
-QUnit[ jQueryVersionSince( "3.3.0" ) ? "test" : "skip" ]( "jQuery.isArray", function( assert ) {
+QUnit[ jQueryVersionSince( "3.2.0" ) ? "test" : "skip" ]( "jQuery.isArray", function( assert ) {
 	assert.expect( 4 );
 
 	expectWarning( assert, "isArray", 3, function() {


### PR DESCRIPTION
…yVersionSince( "3.3.0" ) ) {" condition.  https://github.com/jquery/jquery-migrate/issues/370

https://github.com/jquery/jquery-migrate/issues/370#issuecomment-662545742