### PR TITLE
CSS: Don't throw when value is number and name is object

### DIFF
--- a/src/jquery/css.js
+++ b/src/jquery/css.js
@@ -107,10 +107,15 @@ jQuery.fn.css = function( name, value ) {
 		} );
 	}
 	if ( typeof value === "number" ) {
-		camelName = camelCase( name );
-		if ( !isAutoPx( camelName ) && !jQuery.cssNumber[ camelName ] ) {
+		if ( typeof name === "object" ) {
 			migrateWarn( "Number-typed values are deprecated for jQuery.fn.css( \"" +
-				name + "\", value )" );
+					JSON.stringify( name ) + "\", value )" );
+		} else {
+			camelName = camelCase( name );
+			if ( !isAutoPx( camelName ) && !jQuery.cssNumber[ camelName ] ) {
+				migrateWarn( "Number-typed values are deprecated for jQuery.fn.css( \"" +
+					name + "\", value )" );
+			}
 		}
 	}
 

--- a/src/jquery/css.js
+++ b/src/jquery/css.js
@@ -105,17 +105,13 @@ jQuery.fn.css = function( name, value ) {
 		jQuery.each( name, function( n, v ) {
 			jQuery.fn.css.call( origThis, n, v );
 		} );
+		return this;
 	}
 	if ( typeof value === "number" ) {
-		if ( typeof name === "object" ) {
+		camelName = camelCase( name );
+		if ( !isAutoPx( camelName ) && !jQuery.cssNumber[ camelName ] ) {
 			migrateWarn( "Number-typed values are deprecated for jQuery.fn.css( \"" +
-					JSON.stringify( name ) + "\", value )" );
-		} else {
-			camelName = camelCase( name );
-			if ( !isAutoPx( camelName ) && !jQuery.cssNumber[ camelName ] ) {
-				migrateWarn( "Number-typed values are deprecated for jQuery.fn.css( \"" +
-					name + "\", value )" );
-			}
+				name + "\", value )" );
 		}
 	}
 

--- a/test/css.js
+++ b/test/css.js
@@ -156,10 +156,6 @@ QUnit.test( "jQuery.cssNumber", function( assert ) {
 } );
 
 QUnit.test( "jQuery.css with object as name and number as value", function( assert ) {
-	assert.expect( 2 );
-	expectWarning( assert, "Object as name, number as value", function() {
-		( jQuery( "<div/>" ).css( { left: "100%" }, 300 ) );
-	} );
-
+	assert.expect( 1 );
 	assert.ok( ( jQuery( "<div/>" ).css( { left: "100%" }, 300 ) ) );
 } );

--- a/test/css.js
+++ b/test/css.js
@@ -154,3 +154,12 @@ QUnit.test( "jQuery.cssNumber", function( assert ) {
 
 	assert.ok( jQuery.cssNumber, "jQuery.cssNumber exists" );
 } );
+
+QUnit.test( "jQuery.css with object as name and number as value", function( assert ) {
+	assert.expect( 2 );
+	expectWarning( assert, "Object as name, number as value", function() {
+		( jQuery( "<div/>" ).css( { left: "100%" }, 300 ) );
+	} );
+
+	assert.ok( ( jQuery( "<div/>" ).css( { left: "100%" }, 300 ) ) );
+} );

--- a/test/css.js
+++ b/test/css.js
@@ -157,5 +157,5 @@ QUnit.test( "jQuery.cssNumber", function( assert ) {
 
 QUnit.test( "An unsupported jQuery.fn.css(Object,Number) signature", function( assert ) {
 	assert.expect( 1 );
-	assert.ok( ( jQuery( "<div/>" ).css( { left: "100%" }, 300 ) ) );
+	assert.ok( ( jQuery( "<div/>" ).css( { left: "100%" }, 300 ), "No crash" ) );
 } );


### PR DESCRIPTION
Don't assume that the name is a string when the value is a number. Doing so will throw an exception.

See an example using jQuery UI Slider: https://jsfiddle.net/mweichert/784kjmoh/17/

Closes #404 