### PR TITLE
Build: Restore the external directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ CDN
 /dist/*
 !/dist/.eslintrc.json
 
-node_modules
+/external
+/node_modules

--- a/.npmignore
+++ b/.npmignore
@@ -7,4 +7,5 @@ coverage
 *.patch
 /*.html
 .DS_Store
+external
 node_modules

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,7 +7,7 @@ module.exports = function( grunt ) {
 	const gzip = require( "gzip-js" );
 
 	const karmaFilesExceptJQuery = [
-		"node_modules/native-promise-only/lib/npo.src.js",
+		"external/npo/npo.js",
 		"dist/jquery-migrate.min.js",
 		"test/data/compareVersions.js",
 
@@ -110,6 +110,20 @@ module.exports = function( grunt ) {
 					"src/**/*.js",
 					"test/**/*.js"
 				]
+			}
+		},
+		npmcopy: {
+			all: {
+				options: {
+					destPrefix: "external"
+				},
+				files: {
+					"npo/npo.js": "native-promise-only/lib/npo.src.js",
+
+					"qunit/qunit.js": "qunit/qunit/qunit.js",
+					"qunit/qunit.css": "qunit/qunit/qunit.css",
+					"qunit/LICENSE.txt": "qunit/LICENSE.txt"
+				}
 			}
 		},
 		uglify: {
@@ -230,6 +244,7 @@ module.exports = function( grunt ) {
 	] );
 
 	grunt.registerTask( "default-no-test", [
+		"npmcopy",
 		"build",
 		"uglify",
 		"lint",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2470,6 +2470,16 @@
 				}
 			}
 		},
+		"grunt-npmcopy": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/grunt-npmcopy/-/grunt-npmcopy-0.2.0.tgz",
+			"integrity": "sha512-iiIpifpz5UCWPYtskdgCbDjKOoSjmwdEj9hvIHZFHVWjjfehXN6VNoeBp9c6v8XuD81BnRLRf8z/rkwmmmxvqA==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3",
+				"lodash": "^4.17.11"
+			}
+		},
 		"gzip-js": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/gzip-js/-/gzip-js-0.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"grunt-contrib-watch": "1.1.0",
 		"grunt-eslint": "23.0.0",
 		"grunt-karma": "4.0.0",
+		"grunt-npmcopy": "0.2.0",
 		"gzip-js": "0.3.2",
 		"karma": "5.0.9",
 		"karma-browserstack-launcher": "1.6.0",

--- a/test/index.html
+++ b/test/index.html
@@ -9,10 +9,10 @@
 
 	<!-- QUnit -->
 	<link rel="stylesheet" href="../node_modules/qunit/qunit/qunit.css" media="screen">
-	<script src="../node_modules/qunit/qunit/qunit.js"></script>
+	<script src="../external/qunit/qunit.js"></script>
 
 	<!-- A promise polyfill -->
-	<script src="../node_modules/native-promise-only/lib/npo.src.js"></script>
+	<script src="../external/npo/npo.js"></script>
 
 	<!-- Load a jQuery and jquery-migrate plugin file based on URL -->
 	<script src="testinit.js"></script>


### PR DESCRIPTION
In c12e1ab660ac14cb1564d1f04121ef21e7b9094b, we removed the `external` directory
in favor of loading some files directly from `node_modules`. This works fine
locally but when deploying code for tests, this makes it impossible to not
deploy `node_modules` as well. To avoid the issue, this change restores usage
of the `external` directory.

One change is that we no longer commit this directory to the repository, its
only purpose is to have clear isolation from `node_modules`.

Ref jquery/jquery#4865