### PR TITLE
Build: Remove remaining occurrences of node_modules in test HTML files

### DIFF
--- a/test/event-lateload.html
+++ b/test/event-lateload.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<title>jQuery Migrate late load event binding test</title>
-	<script src="../node_modules/native-promise-only/lib/npo.src.js"></script>
+	<script src="../external/npo/npo.js"></script>
 
 	<!-- Load a jQuery and jquery-migrate plugin file based on URL -->
 	<script src="testinit.js"></script>

--- a/test/index.html
+++ b/test/index.html
@@ -8,7 +8,7 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 
 	<!-- QUnit -->
-	<link rel="stylesheet" href="../node_modules/qunit/qunit/qunit.css" media="screen">
+	<link rel="stylesheet" href="../external/qunit/qunit.css" media="screen">
 	<script src="../external/qunit/qunit.js"></script>
 
 	<!-- A promise polyfill -->


### PR DESCRIPTION
gh-419 missed a few occurrences. It was overlooked as Chrome & Firefox didn't
fail any tests because of the missing CSS but IE did, see:
http://swarm.jquery.org/job/11000

Ref gh-419