### PR TITLE
CSS: Fix duplicate "JQMIGRATE" prefix in cssProps warning

### DIFF
--- a/src/jquery/css.js
+++ b/src/jquery/css.js
@@ -75,7 +75,7 @@ if ( jQueryVersionSince( "3.4.0" ) && typeof Proxy !== "undefined" ) {
 
 	jQuery.cssProps = new Proxy( jQuery.cssProps || {}, {
 		set: function() {
-			migrateWarn( "JQMIGRATE: jQuery.cssProps is deprecated" );
+			migrateWarn( "jQuery.cssProps is deprecated" );
 			return Reflect.set.apply( this, arguments );
 		}
 	} );


### PR DESCRIPTION
This prefix is added by `migrateWarn()`, but in the case of cssProps, the prefix was also in the string passed as parameter.