### PR TITLE
Add fix for $.fn.data calls

### DIFF
--- a/src/jquery/data.js
+++ b/src/jquery/data.js
@@ -53,7 +53,7 @@ jQuery.fn.extend( {
                         target[ prop ] === undefined
                     ) {
                         migrateWarn(
-                            "jQuery.data() always sets/gets camelCased names: " +
+                            "jQuery.fn.data() always sets/gets camelCased names: " +
                                 prop
                         );
                         return target[ camelCase( prop ) ];
@@ -64,7 +64,7 @@ jQuery.fn.extend( {
         }
         if ( arguments.length > 0 && typeof key === "string" && key !== camelCase( key ) ) {
             migrateWarn(
-                "jQuery.data() always sets/gets camelCased names: " + key
+                "jQuery.fn.data() always sets/gets camelCased names: " + key
             );
             args =
                 arguments.length > 1 ?

--- a/src/jquery/data.js
+++ b/src/jquery/data.js
@@ -45,6 +45,9 @@ jQuery.fn.extend( {
         var args, result;
         if ( arguments.length === 0 && typeof Proxy !== "undefined" ) {
             result = oldFnData.call( this );
+	    if(!result) {
+ 	      return result;
+	    }
             // eslint-disable-next-line no-undef
             return new Proxy( result, {
                 get: function( target, prop ) {

--- a/src/jquery/data.js
+++ b/src/jquery/data.js
@@ -1,8 +1,8 @@
 import { migrateWarn } from "../main.js";
 import { camelCase } from "../utils.js";
 
-var oldData = jQuery.data;
-var oldFnData = jQuery.fn.data;
+var oldData = jQuery.data,
+ oldFnData = jQuery.fn.data;
 
 jQuery.data = function( elem, name, value ) {
 	var curData, sameKeys, key;
@@ -40,36 +40,37 @@ jQuery.data = function( elem, name, value ) {
 	return oldData.apply( this, arguments );
 };
 
-jQuery.fn.extend({
-    data: function(key, value) {
-        if (arguments.length === 0 && typeof Proxy !== 'undefined') {
-            var result = oldFnData.call(this);
-            return new Proxy(result, {
-                get: function(target, prop) {
+jQuery.fn.extend( {
+    data: function( key, value ) {
+        var args, result;
+        if ( arguments.length === 0 && typeof Proxy !== "undefined" ) {
+            result = oldFnData.call( this );
+            return new Proxy( result, {
+                get: function( target, prop ) {
                     if (
-                        prop !== camelCase(prop) &&
-                        target[prop] === undefined
+                        prop !== camelCase( prop ) &&
+                        target[ prop ] === undefined
                     ) {
                         migrateWarn(
-                            'jQuery.data() always sets/gets camelCased names: ' +
+                            "jQuery.data() always sets/gets camelCased names: " +
                                 prop
                         );
-                        return target[camelCase(prop)];
+                        return target[ camelCase( prop ) ];
                     }
-                    return target[prop];
+                    return target[ prop ];
                 }
-            });
+            } );
         }
-        if (arguments.length > 0 && typeof key === 'string' && key !== camelCase(key)) {
+        if ( arguments.length > 0 && typeof key === "string" && key !== camelCase( key ) ) {
             migrateWarn(
-                'jQuery.data() always sets/gets camelCased names: ' + key
+                "jQuery.data() always sets/gets camelCased names: " + key
             );
-            var args =
-                arguments.length > 1
-                    ? [camelCase(key), value]
-                    : [camelCase(key)];
-            return oldFnData.apply(this, args);
+            args =
+                arguments.length > 1 ?
+                    [ camelCase( key ), value ] :
+                    [ camelCase( key ) ];
+            return oldFnData.apply( this, args );
         }
-        return oldFnData.apply(this, arguments);
+        return oldFnData.apply( this, arguments );
     }
-});
+} );

--- a/src/jquery/data.js
+++ b/src/jquery/data.js
@@ -45,6 +45,7 @@ jQuery.fn.extend( {
         var args, result;
         if ( arguments.length === 0 && typeof Proxy !== "undefined" ) {
             result = oldFnData.call( this );
+            // eslint-disable-next-line no-undef
             return new Proxy( result, {
                 get: function( target, prop ) {
                     if (


### PR DESCRIPTION
When calling `$(el).data()`, the received object contains camel-cased keys, this fixes issue #436