### PR TITLE
Tests: Add a new esmodules flag, remove the raw one

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
 				"karma-qunit": "4.1.2",
 				"load-grunt-tasks": "5.1.0",
 				"native-promise-only": "0.8.1",
-				"qunit": "2.18.0",
+				"qunit": "2.19.1",
 				"rollup": "2.70.1",
 				"testswarm": "1.1.2"
 			},
@@ -4193,9 +4193,9 @@
 			}
 		},
 		"node_modules/qunit": {
-			"version": "2.18.0",
-			"resolved": "https://registry.npmjs.org/qunit/-/qunit-2.18.0.tgz",
-			"integrity": "sha512-Xw/zUm5t1JY8SNErki/qtw4fCuaaOZL+bPloZU+0kto+fO8j1JV9MQWqXO4kATfhEyJohlsKZpfg1HF7GOkpXw==",
+			"version": "2.19.1",
+			"resolved": "https://registry.npmjs.org/qunit/-/qunit-2.19.1.tgz",
+			"integrity": "sha512-gSGuw0vErE/rNjnlBW/JmE7NNubBlGrDPQvsug32ejYhcVFuZec9yoU0+C30+UgeCGwq6Ap89K65dMGo+kDGZQ==",
 			"dev": true,
 			"dependencies": {
 				"commander": "7.2.0",
@@ -8465,9 +8465,9 @@
 			"dev": true
 		},
 		"qunit": {
-			"version": "2.18.0",
-			"resolved": "https://registry.npmjs.org/qunit/-/qunit-2.18.0.tgz",
-			"integrity": "sha512-Xw/zUm5t1JY8SNErki/qtw4fCuaaOZL+bPloZU+0kto+fO8j1JV9MQWqXO4kATfhEyJohlsKZpfg1HF7GOkpXw==",
+			"version": "2.19.1",
+			"resolved": "https://registry.npmjs.org/qunit/-/qunit-2.19.1.tgz",
+			"integrity": "sha512-gSGuw0vErE/rNjnlBW/JmE7NNubBlGrDPQvsug32ejYhcVFuZec9yoU0+C30+UgeCGwq6Ap89K65dMGo+kDGZQ==",
 			"dev": true,
 			"requires": {
 				"commander": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"karma-qunit": "4.1.2",
 		"load-grunt-tasks": "5.1.0",
 		"native-promise-only": "0.8.1",
-		"qunit": "2.18.0",
+		"qunit": "2.19.1",
 		"rollup": "2.70.1",
 		"testswarm": "1.1.2"
 	},

--- a/test/data/compareVersions.js
+++ b/test/data/compareVersions.js
@@ -1,5 +1,5 @@
 // Returns 0 if v1 == v2, -1 if v1 < v2, 1 if v1 > v2
-function compareVersions( v1, v2 ) {
+window.compareVersions = function compareVersions( v1, v2 ) {
 	var i,
 		rVersionParts = /^(\d+)\.(\d+)\.(\d+)/,
 		v1p = rVersionParts.exec( v1 ) || [ ],
@@ -14,8 +14,8 @@ function compareVersions( v1, v2 ) {
 		}
 	}
 	return 0;
-}
+};
 
-function jQueryVersionSince( version ) {
+window.jQueryVersionSince = function jQueryVersionSince( version ) {
 	return compareVersions( jQuery.fn.jquery, version ) >= 0;
-}
+};

--- a/test/data/qunit-start.js
+++ b/test/data/qunit-start.js
@@ -1,0 +1,1 @@
+QUnit.start();

--- a/test/data/test-utils.js
+++ b/test/data/test-utils.js
@@ -1,6 +1,6 @@
 /* exported expectWarning, expectNoWarning */
 
-function expectWarning( assert, name, expected, fn ) {
+window.expectWarning = function expectWarning( assert, name, expected, fn ) {
 	var result;
 	if ( !fn ) {
 		fn = expected;
@@ -41,10 +41,10 @@ function expectWarning( assert, name, expected, fn ) {
 		check();
 		return Promise.resolve();
 	}
-}
+};
 
-function expectNoWarning( assert, name, expected, fn ) {
+window.expectNoWarning = function expectNoWarning( assert, name, expected, fn ) {
 
 	// Expected is present only for signature compatibility with expectWarning
 	return expectWarning( assert, name, 0, fn || expected );
-}
+};

--- a/test/index.html
+++ b/test/index.html
@@ -29,20 +29,9 @@
 	<script src="data/compareVersions.js"></script>
 
 	<!-- Unit test files -->
-	<script src="data/test-utils.js"></script>
-	<script src="unit/migrate.js"></script>
-	<script src="unit/jquery/core.js"></script>
-	<script src="unit/jquery/ajax.js"></script>
-	<script src="unit/jquery/attributes.js"></script>
-	<script src="unit/jquery/css.js"></script>
-	<script src="unit/jquery/data.js"></script>
-	<script src="unit/jquery/effects.js"></script>
-	<script src="unit/jquery/event.js"></script>
-	<script src="unit/jquery/manipulation.js"></script>
-	<script src="unit/jquery/offset.js"></script>
-	<script src="unit/jquery/serialize.js"></script>
-	<script src="unit/jquery/traversing.js"></script>
-	<script src="unit/jquery/deferred.js"></script>
+	<script>
+		TestManager.loadTests();
+	</script>
 </head>
 <body>
 	<div id="qunit"></div>


### PR DESCRIPTION
Migrating from AMD to ES modules in gh-343 made the `raw` testing mode break as
it relied on loading raw source files. This change removes the `raw` mode in
favor of the new `esmodules` one.

Setup is different than in jQuery as jQuery uses AMD to load tests and Migrate
just loads test files directly.

When Migrate is loaded via its source ES modules, test files are loaded as
modules as well. This is necessary as module scripts behave as if loaded with
the `defer` attribute so tests need to be deferred as well.

Iframe tests are skipped in `esmodules` mode as their setup is incompatible
with the above considerations.

In addition to the above, Karma tests now also run in esmodules mode for easier
verification this mode is not broken by PRs.

Ref gh-343