### PR TITLE
Build: Downgrade uglify-js to fix tests in IE 9

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -169,8 +169,8 @@ module.exports = function( grunt ) {
 
 						// Support: Android 4.0 only
 						// UglifyJS 3 breaks Android 4.0 if this option is not enabled.
-						// This is in lieu of setting ie for all of mangle, compress, and output
-						ie: true
+						// This is in lieu of setting ie8 for all of mangle, compress, and output
+						ie8: true
 					},
 					banner: "/*! jQuery Migrate v<%= pkg.version %>" +
 						" | (c) <%= pkg.author.name %> | jquery.org/license */",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"grunt": "1.5.3",
 				"grunt-cli": "1.4.3",
 				"grunt-compare-size": "0.4.2",
-				"grunt-contrib-uglify": "5.0.1",
+				"grunt-contrib-uglify": "4.0.1",
 				"grunt-contrib-watch": "1.1.0",
 				"grunt-eslint": "24.0.0",
 				"grunt-karma": "4.0.2",
@@ -2151,18 +2151,18 @@
 			}
 		},
 		"node_modules/grunt-contrib-uglify": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-5.0.1.tgz",
-			"integrity": "sha512-T/aXZ4WIpAtoswZqb6HROKg7uq9QbKwl+lUuOwK4eoFj3tFv9/a/oMyd3/qvetV29Pbf8P1YYda1gDwZppr60A==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-4.0.1.tgz",
+			"integrity": "sha512-dwf8/+4uW1+7pH72WButOEnzErPGmtUvc8p08B0eQS/6ON0WdeQu0+WFeafaPTbbY1GqtS25lsHWaDeiTQNWPg==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^2.4.1",
 				"maxmin": "^2.1.0",
-				"uglify-js": "^3.13.3",
+				"uglify-js": "^3.5.0",
 				"uri-path": "^1.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=6"
 			}
 		},
 		"node_modules/grunt-contrib-uglify/node_modules/ansi-styles": {
@@ -2206,6 +2206,12 @@
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 			"dev": true
 		},
+		"node_modules/grunt-contrib-uglify/node_modules/commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true
+		},
 		"node_modules/grunt-contrib-uglify/node_modules/escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -2234,6 +2240,21 @@
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/grunt-contrib-uglify/node_modules/uglify-js": {
+			"version": "3.9.4",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.4.tgz",
+			"integrity": "sha512-8RZBJq5smLOa7KslsNsVcSH+KOXf1uDU8yqLeNuVKwmT0T3FA0ZoXlinQfRad7SDcbZZRZE4ov+2v71EnxNyCA==",
+			"dev": true,
+			"dependencies": {
+				"commander": "~2.20.3"
+			},
+			"bin": {
+				"uglifyjs": "bin/uglifyjs"
+			},
+			"engines": {
+				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/grunt-contrib-watch": {
@@ -4927,18 +4948,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/uglify-js": {
-			"version": "3.15.3",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.3.tgz",
-			"integrity": "sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==",
-			"dev": true,
-			"bin": {
-				"uglifyjs": "bin/uglifyjs"
-			},
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
 		"node_modules/unbox-primitive": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -6942,14 +6951,14 @@
 			}
 		},
 		"grunt-contrib-uglify": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-5.0.1.tgz",
-			"integrity": "sha512-T/aXZ4WIpAtoswZqb6HROKg7uq9QbKwl+lUuOwK4eoFj3tFv9/a/oMyd3/qvetV29Pbf8P1YYda1gDwZppr60A==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-4.0.1.tgz",
+			"integrity": "sha512-dwf8/+4uW1+7pH72WButOEnzErPGmtUvc8p08B0eQS/6ON0WdeQu0+WFeafaPTbbY1GqtS25lsHWaDeiTQNWPg==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.1",
 				"maxmin": "^2.1.0",
-				"uglify-js": "^3.13.3",
+				"uglify-js": "^3.5.0",
 				"uri-path": "^1.0.0"
 			},
 			"dependencies": {
@@ -6988,6 +6997,12 @@
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 					"dev": true
 				},
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+					"dev": true
+				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -7007,6 +7022,15 @@
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
+					}
+				},
+				"uglify-js": {
+					"version": "3.9.4",
+					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.4.tgz",
+					"integrity": "sha512-8RZBJq5smLOa7KslsNsVcSH+KOXf1uDU8yqLeNuVKwmT0T3FA0ZoXlinQfRad7SDcbZZRZE4ov+2v71EnxNyCA==",
+					"dev": true,
+					"requires": {
+						"commander": "~2.20.3"
 					}
 				}
 			}
@@ -8997,12 +9021,6 @@
 			"version": "0.7.31",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
 			"integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==",
-			"dev": true
-		},
-		"uglify-js": {
-			"version": "3.15.3",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.3.tgz",
-			"integrity": "sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==",
 			"dev": true
 		},
 		"unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"grunt": "1.5.3",
 		"grunt-cli": "1.4.3",
 		"grunt-compare-size": "0.4.2",
-		"grunt-contrib-uglify": "5.0.1",
+		"grunt-contrib-uglify": "4.0.1",
 		"grunt-contrib-watch": "1.1.0",
 		"grunt-eslint": "24.0.0",
 		"grunt-karma": "4.0.2",


### PR DESCRIPTION
We can upgrade for Migrate 4.0. It's not worth spending time on figuring out how to fix IE 9 with new UglifyJS at this point.

The `ie` option had to be renamed to `ie8` as the older version doesn't support the former. In Migrate 4 we can remove it altogether.