### PR TITLE
Build: Remove `.editorconfig` overrides for package.json

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,8 +9,3 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-
-[package.json]
-indent_style = space
-indent_size = 2
-


### PR DESCRIPTION
Newer npm version support detecting the indent type of `package.json` and follow it when updating the file. We already use tabs in the file so the current override wasn't even respected.