### PR TITLE
Build: Improve security of the GitHub Actions setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,10 +12,10 @@ jobs:
         NODE_VERSION: [10.x, 18.x]
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Cache
-      uses: actions/cache@v2
+      uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ matrix.NODE_VERSION }}-npm-lock-${{ hashFiles('**/package-lock.json') }}
@@ -23,7 +23,7 @@ jobs:
           ${{ runner.os }}-node-${{ matrix.NODE_VERSION }}-npm-lock-
 
     - name: Use Node.js ${{ matrix.NODE_VERSION }}
-      uses: actions/setup-node@v2.1.2
+      uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
       with:
         node-version: ${{ matrix.NODE_VERSION }}
 


### PR DESCRIPTION
Changes:
1. Reference concrete hashes of actions with versions in comments
2. Update actions to recent versions
3. Set up automatic dependabot montly PRs updating actions

Fortunately, hashes with versions in comments is syntax recognized by dependabot automatic updates; we're using it with success in jQuery Core.