### PR TITLE
Build: Don't run CI push workflows for dependabot branches

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches-ignore: "dependabot/**"
 
 jobs:
   build:


### PR DESCRIPTION
Without this change, dependabot PRs run double checks - one set for the `push` part and one for the `pull_request` part.

Ref jquery/jquery#5353