### PR TITLE
Build: Fix git hooks

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx commitplease .git/COMMIT_EDITMSG

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
 				"express": "4.19.2",
 				"express-body-parser-error-handler": "1.0.7",
 				"globals": "15.3.0",
+				"husky": "9.0.11",
 				"native-promise-only": "0.8.1",
 				"qunit": "2.21.0",
 				"rollup": "4.18.0",
@@ -2318,6 +2319,21 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
+		},
+		"node_modules/husky": {
+			"version": "9.0.11",
+			"resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
+			"integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
+			"dev": true,
+			"bin": {
+				"husky": "bin.mjs"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/typicode"
+			}
 		},
 		"node_modules/iconv-lite": {
 			"version": "0.4.24",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"build": "node build/tasks/build-default.js",
 		"lint": "eslint --cache .",
 		"npmcopy": "node build/tasks/npmcopy.js",
+		"prepare": "husky",
 		"pretest": "npm run npmcopy && npm run build && npm run lint",
 		"start": "npm run npmcopy && node build/tasks/build-watch.js",
 		"test:browser": "npm run pretest && npm run test:unit -- -b chrome -b firefox -h",
@@ -47,6 +48,7 @@
 		"express": "4.19.2",
 		"express-body-parser-error-handler": "1.0.7",
 		"globals": "15.3.0",
+		"husky": "9.0.11",
 		"native-promise-only": "0.8.1",
 		"qunit": "2.21.0",
 		"rollup": "4.18.0",
@@ -62,6 +64,7 @@
 		"migrate"
 	],
 	"commitplease": {
+		"nohook": true,
 		"components": [
 			"Docs",
 			"Tests",


### PR DESCRIPTION
Git hooks are broken since gh-512; this change fixes them by migrating to Husky as jQuery Core did.

Without this fix, even `git commit --no-verify` doesn't work; only manually deleting the `.git/hooks` directory and re-running `git commit` does.

Ref gh-512