### PR TITLE
Manipulation: Deprecate jQuery.UNSAFE_restoreLegacyHtmlPrefilter

### DIFF
--- a/src/jquery/manipulation.js
+++ b/src/jquery/manipulation.js
@@ -1,4 +1,4 @@
-import { migratePatchFunc, migrateWarn } from "../main.js";
+import { migratePatchAndWarnFunc, migratePatchFunc, migrateWarn } from "../main.js";
 import "../disablePatches.js";
 
 var rxhtmlTag = /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([a-z][^\/\0>\x20\t\r\n\f]*)[^>]*)\/>/gi,
@@ -19,9 +19,11 @@ var rxhtmlTag = /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([a-z][^\/\
  * Deprecated, please use `jQuery.migrateDisablePatches( "self-closed-tags" )` instead.
  * @deprecated
  */
-jQuery.UNSAFE_restoreLegacyHtmlPrefilter = function() {
+migratePatchAndWarnFunc( jQuery, "UNSAFE_restoreLegacyHtmlPrefilter", function() {
 	jQuery.migrateEnablePatches( "self-closed-tags" );
-};
+}, "legacy-self-closed-tags",
+"jQuery.UNSAFE_restoreLegacyHtmlPrefilter deprecated; use " +
+	"`jQuery.migrateEnablePatches( \"self-closed-tags\" )`" );
 
 migratePatchFunc( jQuery, "htmlPrefilter", function( html ) {
 	warnIfChanged( html );

--- a/test/unit/jquery/manipulation.js
+++ b/test/unit/jquery/manipulation.js
@@ -41,9 +41,11 @@ QUnit.test( "Improperly closed elements", function( assert ) {
 } );
 
 QUnit.test( "jQuery.UNSAFE_restoreLegacyHtmlPrefilter (deprecated)", function( assert ) {
-	assert.expect( 5 );
+	assert.expect( 7 );
 
-	jQuery.UNSAFE_restoreLegacyHtmlPrefilter();
+	expectWarning( assert, "jQuery.UNSAFE_restoreLegacyHtmlPrefilter()", 1, function() {
+		jQuery.UNSAFE_restoreLegacyHtmlPrefilter();
+	} );
 
 	var warns = jQuery.migrateWarnings,
 		elem = jQuery( "<div/><span/>" ),
@@ -55,6 +57,7 @@ QUnit.test( "jQuery.UNSAFE_restoreLegacyHtmlPrefilter (deprecated)", function( a
 	assert.strictEqual( firstNodeName, "div", "Proper first element" );
 	assert.strictEqual( secondNodeName, "span", "Proper second element" );
 
-	assert.equal( warns.length, 1, "Proper warning length" );
-	assert.ok( warns[ 0 ].indexOf( "HTML tags" ) >= 0, warns[ 0 ] );
+	assert.equal( warns.length, 2, "Proper warning length" );
+	assert.ok( warns[ 0 ].indexOf( "jQuery.UNSAFE_restoreLegacyHtmlPrefilter" ) >= 0, warns[ 0 ] );
+	assert.ok( warns[ 1 ].indexOf( "HTML tags" ) >= 0, warns[ 1 ] );
 } );


### PR DESCRIPTION
This is unusual as it's not the Core API but we support this patch via a more generic API now:

```
jQuery.migrateEnablePatches( "self-closed-tags" )
```

Fixes gh-474