### PR TITLE
Release: Fix the release script

### DIFF
--- a/build/release.js
+++ b/build/release.js
@@ -7,9 +7,9 @@
 var	dryrun = false,
 	skipRemote = false;
 
-import fs from "fs";
-import child from "child_process";
-import path from "path";
+import fs from "node:fs";
+import child from "node:child_process";
+import path from "node:path";
 import chalk from "chalk";
 import enquirer from "enquirer";
 import { build } from "./tasks/build";
@@ -98,7 +98,7 @@ function initialize( next ) {
 	if ( !( fs.existsSync || path.existsSync )( packageFile ) ) {
 		die( "No " + packageFile + " in this directory" );
 	}
-	pkg = JSON.parse( fs.readFileSync( packageFile ) );
+	pkg = JSON.parse( fs.readFileSync( packageFile, "utf8" ) );
 
 	status( "Current version is " + pkg.version + "; generating release " + releaseVersion );
 	version = rsemver.exec( pkg.version );

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"chalk": "5.3.0",
 				"commitplease": "3.2.0",
 				"diff": "5.2.0",
+				"enquirer": "2.4.1",
 				"eslint": "8.57.0",
 				"eslint-config-jquery": "3.0.2",
 				"eslint-plugin-import": "2.29.1",
@@ -645,6 +646,15 @@
 				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
+		"node_modules/ansi-colors": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+			"integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1251,6 +1261,19 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/enquirer": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+			"integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-colors": "^4.1.1",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8.6"
 			}
 		},
 		"node_modules/es-abstract": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"chalk": "5.3.0",
 		"commitplease": "3.2.0",
 		"diff": "5.2.0",
+		"enquirer": "2.4.1",
 		"eslint": "8.57.0",
 		"eslint-config-jquery": "3.0.2",
 		"eslint-plugin-import": "2.29.1",


### PR DESCRIPTION
PR gh-503 erroneously removed the `enquirer` dependency, required for the release process. Restore it.

In addition, update built-in module imports to use the `node:` prefix and add a missing "utf8" value in one `fs.readFileSync`.