### PR TITLE
Release: Fix the path to `build.js`

### DIFF
--- a/build/release.js
+++ b/build/release.js
@@ -12,7 +12,7 @@ import child from "node:child_process";
 import path from "node:path";
 import chalk from "chalk";
 import enquirer from "enquirer";
-import { build } from "./tasks/build";
+import { build } from "./tasks/build.js";
 
 var releaseVersion,
 	nextVersion,


### PR DESCRIPTION
ES modules require extensions in import paths.

The dry run:
```
node build/release.js -d 3.5.0
```
succeeded after this fix.