### PR TITLE
Build: Fix tests in IE 10 & 9, ensure ES5 in tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -89,10 +89,12 @@ export default [
 	{
 		files: [ "test/unit/**" ],
 		languageOptions: {
-			ecmaVersion: 2015,
+			ecmaVersion: 5,
 			sourceType: "script",
 			globals: {
 				...globals.browser,
+				Promise: false,
+				Symbol: false,
 				jQuery: false,
 				QUnit: false,
 				url: false,
@@ -117,10 +119,12 @@ export default [
 		files: [ "test/data/**" ],
 		ignores: [ "test/data/jquery-*.js", "test/data/qunit-start.js" ],
 		languageOptions: {
-			ecmaVersion: 2015,
+			ecmaVersion: 5,
 			sourceType: "script",
 			globals: {
 				...globals.browser,
+				Promise: false,
+				Symbol: false,
 				global: false,
 				jQuery: false,
 				QUnit: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "jquery-migrate",
-	"version": "3.5.1-pre",
+	"version": "3.5.3-pre",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "jquery-migrate",
-			"version": "3.5.1-pre",
+			"version": "3.5.3-pre",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/selenium-webdriver": "4.1.22",

--- a/test/unit/jquery/core.js
+++ b/test/unit/jquery/core.js
@@ -477,8 +477,8 @@ QUnit[ jQueryVersionSince( "4.0.0" ) ? "test" : "skip" ]( "jQuery.fn.sort", func
 		var elem = jQuery( "<span></span><div></div><p></p>" );
 
 		elem.sort( function( node1, node2 ) {
-			const tag1 = node1.tagName.toLowerCase();
-			const tag2 = node2.tagName.toLowerCase();
+			var tag1 = node1.tagName.toLowerCase(),
+				tag2 = node2.tagName.toLowerCase();
 			if ( tag1 < tag2 ) {
 				return -1;
 			}


### PR DESCRIPTION
1. Change `const`s in `core.js` tests to a `var` to avoid crashes in IE 9 & 10.
2. Modify the ESLint config to require ES5 in tests.

The test failure can be viewed at https://github.com/jquery/jquery-migrate/actions/runs/10891333795/job/30228137263.