### PR TITLE
Core: Fix the selector module, make CI green

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
 				"qunit": "2.21.0",
 				"rollup": "4.22.4",
 				"selenium-webdriver": "4.21.0",
-				"sinon": "9.2.4",
+				"sinon": "7.5.0",
 				"uglify-js": "3.9.4",
 				"yargs": "17.7.2"
 			},
@@ -441,26 +441,27 @@
 				"type-detect": "4.0.8"
 			}
 		},
-		"node_modules/@sinonjs/fake-timers": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
-			"integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+		"node_modules/@sinonjs/formatio": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+			"integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"@sinonjs/commons": "^1.7.0"
+				"@sinonjs/commons": "^1",
+				"@sinonjs/samsam": "^3.1.0"
 			}
 		},
 		"node_modules/@sinonjs/samsam": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.1.tgz",
-			"integrity": "sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+			"integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"@sinonjs/commons": "^1.6.0",
-				"lodash.get": "^4.4.2",
-				"type-detect": "^4.0.8"
+				"@sinonjs/commons": "^1.3.0",
+				"array-from": "^2.1.1",
+				"lodash": "^4.17.15"
 			}
 		},
 		"node_modules/@sinonjs/text-encoding": {
@@ -748,6 +749,13 @@
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
 			"integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
 			"dev": true
+		},
+		"node_modules/array-from": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+			"integrity": "sha512-GQTc6Uupx1FCavi5mPzBvVT7nEOeWMmUA9P95wpfpW1XwMSKs+KaymD5C2Up7KAUKg/mYwbsUYzdZWcoajlNZg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/array-includes": {
 			"version": "3.1.8",
@@ -3125,10 +3133,10 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/lodash.get": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+		"node_modules/lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3137,6 +3145,13 @@
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
+		},
+		"node_modules/lolex": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+			"integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/map-stream": {
 			"version": "0.1.0",
@@ -3253,16 +3268,16 @@
 			}
 		},
 		"node_modules/nise": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/nise/-/nise-4.1.0.tgz",
-			"integrity": "sha512-eQMEmGN/8arp0xsvGoQ+B1qvSkR73B1nWSCh7nOt5neMCtwcQVYQGdzQMhcNscktTsWB54xnlSQFzOAPJD8nXA==",
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-1.5.3.tgz",
+			"integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"@sinonjs/commons": "^1.7.0",
-				"@sinonjs/fake-timers": "^6.0.0",
+				"@sinonjs/formatio": "^3.2.1",
 				"@sinonjs/text-encoding": "^0.7.1",
 				"just-extend": "^4.0.2",
+				"lolex": "^5.0.1",
 				"path-to-regexp": "^1.7.0"
 			}
 		},
@@ -3272,6 +3287,16 @@
 			"integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/nise/node_modules/lolex": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+			"integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@sinonjs/commons": "^1.7.0"
+			}
 		},
 		"node_modules/nise/node_modules/path-to-regexp": {
 			"version": "1.9.0",
@@ -4097,46 +4122,53 @@
 			}
 		},
 		"node_modules/sinon": {
-			"version": "9.2.4",
-			"resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
-			"integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-7.5.0.tgz",
+			"integrity": "sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==",
 			"deprecated": "16.1.1",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"@sinonjs/commons": "^1.8.1",
-				"@sinonjs/fake-timers": "^6.0.1",
-				"@sinonjs/samsam": "^5.3.1",
-				"diff": "^4.0.2",
-				"nise": "^4.0.4",
-				"supports-color": "^7.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/sinon"
+				"@sinonjs/commons": "^1.4.0",
+				"@sinonjs/formatio": "^3.2.1",
+				"@sinonjs/samsam": "^3.3.3",
+				"diff": "^3.5.0",
+				"lolex": "^4.2.0",
+				"nise": "^1.5.2",
+				"supports-color": "^5.5.0"
 			}
 		},
 		"node_modules/sinon/node_modules/diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
 			}
 		},
+		"node_modules/sinon/node_modules/has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/sinon/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"has-flag": "^4.0.0"
+				"has-flag": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=4"
 			}
 		},
 		"node_modules/spawnback": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 		"qunit": "2.21.0",
 		"rollup": "4.22.4",
 		"selenium-webdriver": "4.21.0",
-		"sinon": "9.2.4",
+		"sinon": "7.5.0",
 		"uglify-js": "3.9.4",
 		"yargs": "17.7.2"
 	},

--- a/src/jquery/selector.js
+++ b/src/jquery/selector.js
@@ -1,3 +1,4 @@
+import { jQueryVersionSince } from "../compareVersions.js";
 import { migratePatchFunc, migrateWarnProp, migrateWarn } from "../main.js";
 
 // Now jQuery.expr.pseudos is the standard incantation
@@ -11,59 +12,66 @@ function markFunction( fn ) {
 	return fn;
 }
 
-migratePatchFunc( jQuery.expr.filter, "PSEUDO", function( pseudo, argument ) {
+// jQuery older than 3.7.0 used Sizzle which has its own private expando
+// variable that we cannot access. This makes thi patch impossible in those
+// jQuery versions.
+if ( jQueryVersionSince( "3.7.0" ) ) {
+	migratePatchFunc( jQuery.expr.filter, "PSEUDO", function( pseudo, argument ) {
 
-	// pseudo-class names are case-insensitive
-	// https://www.w3.org/TR/selectors/#pseudo-classes
-	// Prioritize by case sensitivity in case custom pseudos are added with uppercase letters
-	// Remember that setFilters inherits from pseudos
-	var args,
-		fn = jQuery.expr.pseudos[ pseudo ] ||
-			jQuery.expr.setFilters[ pseudo.toLowerCase() ] ||
-			jQuery.error( "Syntax error, unrecognized expression: unsupported pseudo: " + pseudo );
+		// pseudo-class names are case-insensitive
+		// https://www.w3.org/TR/selectors/#pseudo-classes
+		// Prioritize by case sensitivity in case custom pseudos are added with uppercase letters
+		// Remember that setFilters inherits from pseudos
+		var args,
+			fn = jQuery.expr.pseudos[ pseudo ] ||
+				jQuery.expr.setFilters[ pseudo.toLowerCase() ] ||
+				jQuery.error(
+					"Syntax error, unrecognized expression: unsupported pseudo: " +
+						pseudo );
 
-	// The user may use createPseudo to indicate that
-	// arguments are needed to create the filter function
-	// just as jQuery does
-	if ( fn[ jQuery.expando ] ) {
-		return fn( argument );
-	}
+		// The user may use createPseudo to indicate that
+		// arguments are needed to create the filter function
+		// just as jQuery does
+		if ( fn[ jQuery.expando ] ) {
+			return fn( argument );
+		}
 
-	// But maintain support for old signatures
-	if ( fn.length > 1 ) {
-		migrateWarn( "legacy-custom-pseudos",
-			"Pseudos with multiple arguments are deprecated; " +
-				"use jQuery.expr.createPseudo()" );
-		args = [ pseudo, pseudo, "", argument ];
-		return jQuery.expr.setFilters.hasOwnProperty( pseudo.toLowerCase() ) ?
-			markFunction( function( seed, matches ) {
-				var idx,
-					matched = fn( seed, argument ),
-					i = matched.length;
-				while ( i-- ) {
-					idx = Array.prototype.indexOf.call( seed, matched[ i ] );
-					seed[ idx ] = !( matches[ idx ] = matched[ i ] );
+		// But maintain support for old signatures
+		if ( fn.length > 1 ) {
+			migrateWarn( "legacy-custom-pseudos",
+				"Pseudos with multiple arguments are deprecated; " +
+					"use jQuery.expr.createPseudo()" );
+			args = [ pseudo, pseudo, "", argument ];
+			return jQuery.expr.setFilters.hasOwnProperty( pseudo.toLowerCase() ) ?
+				markFunction( function( seed, matches ) {
+					var idx,
+						matched = fn( seed, argument ),
+						i = matched.length;
+					while ( i-- ) {
+						idx = Array.prototype.indexOf.call( seed, matched[ i ] );
+						seed[ idx ] = !( matches[ idx ] = matched[ i ] );
+					}
+				} ) :
+				function( elem ) {
+					return fn( elem, 0, args );
+				};
+		}
+
+		return fn;
+	}, "legacy-custom-pseudos" );
+
+	if ( typeof Proxy !== "undefined" ) {
+		jQuery.each( [ "pseudos", "setFilters" ], function( _, api ) {
+			jQuery.expr[ api ] = new Proxy( jQuery.expr[ api ], {
+				set: function( _target, _prop, fn ) {
+					if ( typeof fn === "function" && !fn[ jQuery.expando ] && fn.length > 1 ) {
+						migrateWarn( "legacy-custom-pseudos",
+							"Pseudos with multiple arguments are deprecated; " +
+								"use jQuery.expr.createPseudo()" );
+					}
+					return Reflect.set.apply( this, arguments );
 				}
-			} ) :
-			function( elem ) {
-				return fn( elem, 0, args );
-			};
-	}
-
-	return fn;
-}, "legacy-custom-pseudos" );
-
-if ( typeof Proxy !== "undefined" ) {
-	jQuery.each( [ "pseudos", "setFilters" ], function( _, api ) {
-		jQuery.expr[ api ] = new Proxy( jQuery.expr[ api ], {
-			set: function( _target, _prop, fn ) {
-				if ( typeof fn === "function" && !fn[ jQuery.expando ] && fn.length > 1 ) {
-					migrateWarn( "legacy-custom-pseudos",
-						"Pseudos with multiple arguments are deprecated; " +
-							"use jQuery.expr.createPseudo()" );
-				}
-				return Reflect.set.apply( this, arguments );
-			}
+			} );
 		} );
-	} );
+	}
 }

--- a/test/unit/jquery/ajax.js
+++ b/test/unit/jquery/ajax.js
@@ -30,7 +30,11 @@ QUnit.test( "jQuery.ajax() deprecations on jqXHR", function( assert ) {
 	function runTests( options ) {
 		var forceEnablePatch = ( options || {} ).forceEnablePatch || false;
 
-		QUnit.test( "jQuery.ajax() JSON-to-JSONP auto-promotion" + label + (
+		// Support: IE <10 only
+		// IE 9 doesn't support CORS, skip cross-domain tests there.
+		QUnit[
+			document.documentMode < 10 && crossDomain ? "skip" : "test"
+		]( "jQuery.ajax() JSON-to-JSONP auto-promotion" + label + (
 			forceEnablePatch ? ", patch force-enabled" : ""
 		), function( assert ) {
 

--- a/test/unit/jquery/deferred.js
+++ b/test/unit/jquery/deferred.js
@@ -123,7 +123,11 @@ QUnit.test( "jQuery.Deferred.getStackHook - setter", function( assert ) {
 	} );
 } );
 
-QUnit.test( "jQuery.Deferred.getStackHook - disabled patch, getter", function( assert ) {
+// jQuery.Deferred.getErrorHook was introduced in jQuery 3.7.0 and this test
+// depends on it.
+QUnit[
+	jQueryVersionSince( "3.7.0" ) ? "test" : "skip"
+]( "jQuery.Deferred.getStackHook - disabled patch, getter", function( assert ) {
 	assert.expect( 5 );
 
 	var exceptionHookSpy,

--- a/test/unit/jquery/selector.js
+++ b/test/unit/jquery/selector.js
@@ -189,11 +189,20 @@ QUnit.test( "custom pseudos", function( assert ) {
 	} );
 } );
 
-QUnit.test( "backwards-compatible custom pseudos", function( assert ) {
+QUnit[
+	jQueryVersionSince( "3.7.0" ) ? "test" : "skip"
+]( "backwards-compatible custom pseudos", function( assert ) {
 	assert.expect( 7 );
 
+	var expectWarningWithProxy = typeof Proxy !== "undefined" ?
+		expectWarning :
+		function( _assert, _title, fn ) {
+			fn();
+			assert.ok( true, "No Proxy => warnings not expected" );
+		};
+
 	try {
-		expectWarning( assert, "Custom element filter with argument - setter", function() {
+		expectWarningWithProxy( assert, "Custom element filter with argument - setter", function() {
 			jQuery.expr.pseudos.icontains = function( elem, i, match ) {
 				return jQuery
 					.text( elem )
@@ -214,7 +223,7 @@ QUnit.test( "backwards-compatible custom pseudos", function( assert ) {
 	}
 
 	try {
-		expectWarning( assert, "Custom setFilter pseudo - setter", function() {
+		expectWarningWithProxy( assert, "Custom setFilter pseudo - setter", function() {
 			jQuery.expr.setFilters.podium = function( elements, argument ) {
 				var count = argument == null || argument === "" ? 3 : +argument;
 				return elements.slice( 0, count );


### PR DESCRIPTION
~~**Note:** Please don't review the first commit, that's #551. I based it like that so that I can see the tests pass; it should be "unbased" before merging. For this reason alone I'm marking this as a draft.~~

Changes:
1. Support legacy pseudos only in jQuery 3.7.0+.
2. Downgrade sinon to a version working with IE 9+.
3. Skip cross-domain ajax tests in IE 9.
4. Skip tests requiring `jQuery.Deferred.getErrorHook` in <3.7.
5. Don't require warnings for backwards-compatible pseudos if Proxy unsupported.