### PR TITLE
Event: Patch jQuery.event.global

### DIFF
--- a/src/jquery/event.js
+++ b/src/jquery/event.js
@@ -1,5 +1,6 @@
 import {
 	migrateWarn,
+	migrateWarnProp,
 	migratePatchAndInfoFunc,
 	migratePatchFunc
 } from "../main.js";
@@ -41,3 +42,6 @@ migratePatchAndInfoFunc( jQuery.fn, "undelegate", jQuery.fn.undelegate,
 
 migratePatchAndInfoFunc( jQuery.fn, "hover", jQuery.fn.hover,
 	"hover", "jQuery.fn.hover() is deprecated" );
+
+migrateWarnProp( jQuery.event, "global", {}, "event-global",
+	"jQuery.event.global is removed" );

--- a/test/unit/jquery/event.js
+++ b/test/unit/jquery/event.js
@@ -84,3 +84,12 @@ TestManager.runIframeTest( "Load within a ready handler", "event-lateload.html",
 			JSON.stringify( jQuery.migrateMessages ) );
 		assert.ok( /load/.test( jQuery.migrateMessages[ 0 ] ), "message ok" );
 	} );
+
+QUnit.test( "jQuery.event.global", function( assert ) {
+	assert.expect( 3 );
+
+	expectMessage( assert, "jQuery.event.global", 2, function() {
+		assert.ok( jQuery.isPlainObject( jQuery.event.global ), "is a plain object" );
+		assert.deepEqual( jQuery.event.global, {}, "is an empty object" );
+	} );
+} );

--- a/warnings.md
+++ b/warnings.md
@@ -171,6 +171,12 @@ This is _not_ a warning, but a console log message the plugin shows when it firs
 
 **Solution:** Rename all usage of `jQuery.Deferred.getStackHook` to `jQuery.Deferred.getErrorHook`. If you previously assigned a function returning an error stack to `jQuery.Deferred.getStackHook` or `jQuery.Deferred.getErrorHook`, change it to return a full error object. If you aim to still support jQuery <3.7, assign the hook to `jQuery.Deferred.getErrorHook` first and only later to `jQuery.Deferred.getStackHook` to avoid a Migrate warning.
 
+### \[event-global\] JQMIGRATE: jQuery.Deferred.getStackHook is removed; use jQuery.Deferred.getErrorHook
+
+**Cause:** `jQuery.event.global` was an object with keys being event names for which event listeners have ever been added. Originally, it was needed for performance reasons and to fix memory leaks in old IE, but since jQuery 1.9.0, the library has only been recording the events, but it was not using that information anywhere. jQuery 4.0.0 removes the API.
+
+**Solution:** Remove all usage of `jQuery.event.global`; it's unlikely any existing usage is needed.
+
 
 ## Deprecated APIs
 


### PR DESCRIPTION
The API has been write-only since 1.9.0 and is going to be removed in jQuery 4.0.0.

Also:
* make it more explicit why certain patches are tested in the context of `jQuery.migrateDisablePatches` & related APIs
* fix an erroneous future tense in a few warnings