### PR TITLE
Build: Make browser tests correctly run on multiple jQuery versions

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -43,7 +43,11 @@ jobs:
         run: npm install
 
       - name: Run tests
-        run: npm run test:browser -- -f plugin=${{ matrix.MIGRATE_VERSION }}
+        run: |
+            npm run pretest
+            npm run build:all
+            npm run test:unit -- -c jtr-local.yml \
+              --headless -b ${{ matrix.BROWSER }} -f plugin=${{ matrix.MIGRATE_VERSION }}
 
   ie:
     runs-on: windows-latest

--- a/jtr-local.yml
+++ b/jtr-local.yml
@@ -1,6 +1,6 @@
 version: 1
 
-flags:
+runs:
   jquery:
     - git
     - git.min


### PR DESCRIPTION
There was a typo in `jtr-local.yml`, making the runs using it load with a huge
query string containing all the jQuery versions listed joined.

Also, only IE and Safari runs even tried to use this config - the default run
was not even reading the BROWSERS env variable.

This all meant only one jQuery version was actually tested.

Ref gh-576