### PR TITLE
Build: Make browser tests correctly run on multiple jQuery versions

### DIFF
--- a/jtr-local.yml
+++ b/jtr-local.yml
@@ -1,6 +1,6 @@
 version: 1
 
-flags:
+runs:
   jquery:
     - 3.x-git
     - 3.x-git.min


### PR DESCRIPTION
There was a typo in `jtr-local.yml`, making the runs using it load with a huge query string containing all the jQuery versions listed joined.

This all meant only one jQuery version was actually tested.

Ref gh-575