### PR TITLE
Tests: Run tests on both real Firefox ESRs

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -22,6 +22,12 @@ jobs:
           - NAME: "Node"
             BROWSER: "chrome"
             MIGRATE_VERSION: "esmodules"
+          - NAME: "Firefox ESR (new)"
+            BROWSER: "firefox"
+            MIGRATE_VERSION: "min"
+          - NAME: "Firefox ESR (old)"
+            BROWSER: "firefox"
+            MIGRATE_VERSION: "min"
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -38,6 +44,23 @@ jobs:
           key: ${{ runner.os }}-node-${{ env.NODE_VERSION }}-npm-lock-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-${{ env.NODE_VERSION }}-npm-lock-
+
+      - name: Set download URL for Firefox ESR (old)
+        run: |
+            echo "FIREFOX_SOURCE_URL=https://download.mozilla.org/?product=firefox-esr-latest-ssl&lang=en-US&os=linux64" >> "$GITHUB_ENV"
+        if: contains(matrix.NAME, 'Firefox ESR (old)')
+
+      - name: Set download URL for Firefox ESR (new)
+        run: |
+            echo "FIREFOX_SOURCE_URL=https://download.mozilla.org/?product=firefox-esr-next-latest-ssl&lang=en-US&os=linux64" >> "$GITHUB_ENV"
+        if: contains(matrix.NAME, 'Firefox ESR (new)')
+
+      - name: Install Firefox ESR
+        run: |
+            wget --no-verbose $FIREFOX_SOURCE_URL -O - | tar -jx -C ${HOME}
+            echo "PATH=${HOME}/firefox:$PATH" >> "$GITHUB_ENV"
+            echo "FIREFOX_BIN=${HOME}/firefox/firefox" >> "$GITHUB_ENV"
+        if: contains(matrix.NAME, 'Firefox ESR')
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -34,7 +34,6 @@ jobs:
           - 'Edge_latest-1'
           - 'Firefox_latest'
           - 'Firefox_latest-1'
-          - 'Firefox_115'
           - '__iOS_18'
           - '__iOS_17'
           - '__iOS_16'


### PR DESCRIPTION
1. At the same time, there may be two supported versions of Firefox ESR. Run tests on both, installed locally.
2. Don't run tests on Firefox 115 on BrowserStack - it was added as there's an ESR version of Firefox 115, but ESR versions may be different, e.g. for some time ServiceWorker was disabled on ESR versions: https://bugzilla.mozilla.org/show_bug.cgi?id=1547023

Ref jquery/jquery#5547