### PR TITLE
Docs: Improve the solution for `boolean-attributes`

### DIFF
--- a/warnings.md
+++ b/warnings.md
@@ -56,7 +56,7 @@ This is _not_ a warning, but a console log message the plugin shows when it firs
 
 **Cause**: Prior to jQuery 4.0, when calling `.attr( name, value )` with any non-`false` non-`null` `value`, jQuery would actually set it to `name`. Similarly, regardless of the actual value, `.attr( name )` used to return `name` lowercased. jQuery 4.0 removes this special behavior.
 
-**Solution**: Always set boolean attributes to their names, whether when using jQuery (`.attr( name, name )`), native APIs (`.setAttribute( name, name )`) or directly in HTML (`<input checked="checked">`).
+**Solution**: Always set boolean attributes to their names, whether when using jQuery (`.attr( name, name )`), native APIs (`.setAttribute( name, name )`) or directly in HTML (`<input checked="checked">`). Avoid using the `.attr( name )` getter on boolean attributes, `.prop( name )` is preferred.
 
 ### \[attr-false\] JQMIGRATE: Setting the non-ARIA non-boolean attribute 'NAME' to false
 


### PR DESCRIPTION
Because jQuery 4.0.0 will not transform attribute values in the getter, the following code changes between jQuery 3.x & 4.x:

```js
$( elem ).prop( "disabled", true );
$( elem ).attr( "disabled" );
```

In jQuery 3.x, the reported attribute value is `"disabled"`, in jQuery 4.x it will be an empty string. This may create issues when migrating so Migrate patches and warns against it.

Add a recommendation to avoid using the `.attr()` getter on boolean attrs.