### PR TITLE
Build: Allow jQuery 4.0.0-beta.2 or newer in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		"test": "npm run build:all && npm run lint && npm run test:browserless && npm run test:browser && npm run test:esm"
 	},
 	"peerDependencies": {
-		"jquery": ">=4 <5"
+		"jquery": ">=4.0.0-beta.2 <5"
 	},
 	"devDependencies": {
 		"@rollup/plugin-commonjs": "28.0.3",


### PR DESCRIPTION
The previous range, `>=4 <5` didn't allow jQuery `4.0.0-rc.1` with newer npm versions unless legacy peer deps are enabled.