### PR TITLE
Docs: Tweak README.md & warnings.md - update removal info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![CI Status](https://github.com/jquery/jquery-migrate/actions/workflows/node.js.yml/badge.svg?branch=3.x-stable)
 
-#### NOTE: To upgrade to jQuery 3.0, you first need version 1.12.x or 2.2.x. If you're using an older version, first upgrade to one of these versions using [jQuery Migrate 1.x](https://github.com/jquery/jquery-migrate/tree/1.x-stable#readme), to resolve any compatibility issues. For more information about the changes made in jQuery 3.0, see the [upgrade guide](https://jquery.com/upgrade-guide/3.0/) and [blog post](https://blog.jquery.com/2016/06/09/jquery-3-0-final-released/).
+#### NOTE: To upgrade to jQuery 3.x, you first need version 1.12.x or 2.2.x. If you're using an older version, first upgrade to one of these versions using [jQuery Migrate 1.x](https://github.com/jquery/jquery-migrate/tree/1.x-stable#readme), to resolve any compatibility issues. For more information about the changes made in jQuery 3.0, see the [upgrade guide](https://jquery.com/upgrade-guide/3.0/) and [blog post](https://blog.jquery.com/2016/06/09/jquery-3-0-final-released/).
 
 # jQuery Migrate
 Upgrading libraries such as jQuery can be a lot of work, when breaking changes have been introduced. jQuery Migrate makes this easier, by restoring the APIs that were removed, and additionally shows warnings in the browser console (development version of jQuery Migrate only) when removed and/or deprecated APIs are used.

--- a/warnings.md
+++ b/warnings.md
@@ -64,7 +64,7 @@ This is _not_ a warning, but a console log message the plugin shows when it firs
 
 ### \[shorthand-removed-v3\] JQMIGRATE: jQuery.fn.error() is deprecated
 
-**Cause:** The `$().error()` method was used to attach an "error" event to an element but has been removed in 1.9 to reduce confusion with the `$.error()` method which is unrelated and has not been deprecated. It also serves to discourage the temptation to use `$(window).error()` which does not work because `window.onerror` does not follow standard event handler conventions. The `$().error()` method was removed in jQuery 3.0.
+**Cause:** The `$().error()` method was used to attach an "error" event to an element but has been deprecated in 1.9 to reduce confusion with the `$.error()` method which is unrelated and has not been deprecated. It also serves to discourage the temptation to use `$(window).error()` which does not work because `window.onerror` does not follow standard event handler conventions. The `$().error()` method was removed in jQuery 3.0.
 
 **Solution:** Change any use of `$().error(fn)` to `$().on("error", fn)`.
 
@@ -147,7 +147,7 @@ This is _not_ a warning, but a console log message the plugin shows when it firs
 
 ### \[swap\] JQMIGRATE: jQuery.swap() is undocumented and deprecated
 
-**Cause**: The `jQuery.swap()` method temporarily exchanges a set of CSS properties. It was never documented as part of jQuery's public API and should not be used because it can cause performance problems due to forced layout. This method has been removed in jQuery 3.0.
+**Cause**: The `jQuery.swap()` method temporarily exchanges a set of CSS properties. It was never documented as part of jQuery's public API and should not be used because it can cause performance problems due to forced layout. This method has been removed in jQuery 1.12/2.2.
 
 **Solution**: Rework the code to avoid calling `jQuery.swap()`, or explicitly set and restore the properties you need to change.
 


### PR DESCRIPTION
Changes:
1. In README, mention upgrading to jQuery 3.x, not just 3.0; the `main` branch
   already mentions 4.x, for comparison.
2. Fix incorrect info about when `jQuery.fn.error()` & `jQuery.swap()` have been
   removed.