### PR TITLE
Build: Update browsers tested in BrowserStack

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -27,12 +27,9 @@ jobs:
           - 'IE_11'
           - 'Safari_latest'
             # JTR doesn't take into account the jump from Safari 18 to 26,
-            # so we need to specify versions explicitly. Also, while BrowserStack
-            # already added macOS Tahoe with Safari 26, it's not a stable release
-            # yet, so we need to test on Safari 17 as well.
+            # so we need to specify versions explicitly.
             # See https://github.com/jquery/jquery-test-runner/issues/17
           - 'Safari_18'
-          - 'Safari_17'
           - 'Chrome_latest'
           - 'Chrome_latest-1'
           - 'Opera_latest'
@@ -40,9 +37,9 @@ jobs:
           - 'Edge_latest-1'
           - 'Firefox_latest'
           - 'Firefox_latest-1'
+          - '__iOS_26'
           - '__iOS_18'
           - '__iOS_17'
-          - '__iOS_16'
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
Changes:
1. Remove Safari 17
2. Remove iOS 16
3. Add iOS 26

`3.x` version: gh-602