### PR TITLE
[]

### DIFF
--- a/scripts/verify-jquery-cve-2015-9251.sh
+++ b/scripts/verify-jquery-cve-2015-9251.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Regression guard for CVE-2015-9251 mitigation in test fixture jQuery (ajaxConvert).
+# @see https://github.com/jquery/jquery/commit/2546bb35b89413da5198d54a4539e4ed0aaf6e49
+set -euo pipefail
+root="$(cd "$(dirname "$0")/.." && pwd)"
+jquery="$root/test/data/jquery-3.7.1.js"
+if ! grep -q 's.crossDomain && current === "script"' "$jquery"; then
+  echo "verify-jquery-cve-2015-9251: expected gh-2432 / CVE-2015-9251 guard in ajaxConvert: $jquery" >&2
+  exit 1
+fi
+echo "verify-jquery-cve-2015-9251: ok"

--- a/test/data/jquery-3.7.1.js
+++ b/test/data/jquery-3.7.1.js
@@ -9057,6 +9057,11 @@ function ajaxConvert( s, response, jqXHR, isSuccess ) {
 			// Convert response if prev dataType is non-auto and differs from current
 			} else if ( prev !== "*" && prev !== current ) {
 
+				// Mitigate possible XSS vulnerability (gh-2432) / CVE-2015-9251
+				if ( s.crossDomain && current === "script" ) {
+					continue;
+				}
+
 				// Seek a direct converter
 				conv = converters[ prev + " " + current ] || converters[ "* " + current ];
 


### PR DESCRIPTION
## Summary
Align the bundled test copy **`test/data/jquery-3.7.1.js`** with the jQuery core XSS mitigation for **CVE-2015-9251** / **gh-2432** by adding the same `ajaxConvert` guard as upstream: [`jquery/jquery@2546bb35`](https://github.com/jquery/jquery/commit/2546bb35b89413da5198d54a4539e4ed0aaf6e49).

## Changes
- Insert `if ( s.crossDomain && current === "script" ) { continue; }` in `ajaxConvert` before converter lookup.
- Add `scripts/verify-jquery-cve-2015-9251.sh` to grep for the guard (local/CI helper).

## Reproduction (before)
The fixture file had no `s.crossDomain && current === "script"` branch inside `ajaxConvert`’s `prev !== "*" && prev !== current` block (vulnerable pattern relative to gh-2432).

## Verification
- `bash scripts/verify-jquery-cve-2015-9251.sh` → ok
- `npm run build:all && npm run lint && npm run test:browserless` → pass
- `npm run test:unit -- -b chrome --headless` → 67 passed
- `npm run test:esm` → 67 passed, 3 skipped

**Note:** Full `npm test` (Chrome + Firefox headless) was not completed locally because the Firefox WebDriver failed to install on this machine (`selenium-manager` / geckodriver). Upstream CI should cover Firefox if applicable.

## Scope
Two files: test fixture jQuery copy + small regression script; no changes to migrate library source.

Made with [Cursor](https://cursor.com)