### PR TITLE
Build: Upgrade dependencies, except for sinon,eslint,jsdom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,29 +17,22 @@
 				"eslint": "8.57.1",
 				"eslint-config-jquery": "3.0.2",
 				"eslint-plugin-import": "2.32.0",
-				"globals": "17.6.0",
+				"globals": "17.7.0",
 				"husky": "9.1.7",
 				"jquery": "4.0.0",
-				"jquery-test-runner": "0.3.0",
+				"jquery-test-runner": "0.3.1",
 				"jsdom": "29.1.1",
 				"native-promise-only": "0.8.1",
 				"qunit": "2.26.0",
 				"rollup": "4.62.2",
 				"sinon": "9.2.4",
 				"uglify-js": "3.19.3",
-				"webpack": "5.107.2",
+				"webpack": "5.108.4",
 				"yargs": "18.0.0"
 			},
 			"peerDependencies": {
 				"jquery": ">=4 <5"
 			}
-		},
-		"node_modules/@acemir/cssom": {
-			"version": "0.9.31",
-			"resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
-			"integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@asamuzakjp/css-color": {
 			"version": "5.1.11",
@@ -113,9 +106,9 @@
 			}
 		},
 		"node_modules/@csstools/color-helpers": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
-			"integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+			"integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
 			"dev": true,
 			"funding": [
 				{
@@ -133,9 +126,9 @@
 			}
 		},
 		"node_modules/@csstools/css-calc": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
-			"integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+			"integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -157,9 +150,9 @@
 			}
 		},
 		"node_modules/@csstools/css-color-parser": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.8.tgz",
-			"integrity": "sha512-3chWb7PRLijpJpPIKkDxdu6IBeO5MrFACND57On0j8OPpc0wZibcGc3xAHrSEbOx/KDRyMHoIxGn0w1PhXMYHw==",
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+			"integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
 			"dev": true,
 			"funding": [
 				{
@@ -173,8 +166,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@csstools/color-helpers": "^6.0.2",
-				"@csstools/css-calc": "^3.2.1"
+				"@csstools/color-helpers": "^6.1.0",
+				"@csstools/css-calc": "^3.3.0"
 			},
 			"engines": {
 				"node": ">=20.19.0"
@@ -208,9 +201,9 @@
 			}
 		},
 		"node_modules/@csstools/css-syntax-patches-for-csstree": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
-			"integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+			"integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
 			"dev": true,
 			"funding": [
 				{
@@ -253,9 +246,9 @@
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
-			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-			"integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+			"integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1008,9 +1001,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "26.0.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
-			"integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
+			"version": "26.1.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+			"integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1025,9 +1018,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@ungap/structured-clone": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
-			"integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+			"integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -1510,9 +1503,9 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.10.38",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
-			"integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+			"version": "2.11.1",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.1.tgz",
+			"integrity": "sha512-HYXq73DDpCtNzOmrFsm9eSwCvWCql0RzqjpDzXN9EadiLJ4DNat0nsZ/Bzmy+Ud12mb4/zKDY0cQ805ZzN+i0A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -1533,9 +1526,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.15",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1544,9 +1537,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.28.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-			"integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+			"version": "4.28.7",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+			"integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
 			"dev": true,
 			"funding": [
 				{
@@ -1564,10 +1557,10 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"baseline-browser-mapping": "^2.10.12",
-				"caniuse-lite": "^1.0.30001782",
-				"electron-to-chromium": "^1.5.328",
-				"node-releases": "^2.0.36",
+				"baseline-browser-mapping": "^2.10.44",
+				"caniuse-lite": "^1.0.30001806",
+				"electron-to-chromium": "^1.5.393",
+				"node-releases": "^2.0.51",
 				"update-browserslist-db": "^1.2.3"
 			},
 			"bin": {
@@ -1668,9 +1661,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001799",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-			"integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+			"version": "1.0.30001806",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+			"integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
 			"dev": true,
 			"funding": [
 				{
@@ -1776,13 +1769,13 @@
 			"license": "MIT"
 		},
 		"node_modules/commander": {
-			"version": "14.0.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-			"integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+			"integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=20"
+				"node": ">=22.12.0"
 			}
 		},
 		"node_modules/commitplease": {
@@ -1920,36 +1913,6 @@
 			},
 			"engines": {
 				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-			}
-		},
-		"node_modules/cssstyle": {
-			"version": "5.3.7",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
-			"integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@asamuzakjp/css-color": "^4.1.1",
-				"@csstools/css-syntax-patches-for-csstree": "^1.0.21",
-				"css-tree": "^3.1.0",
-				"lru-cache": "^11.2.4"
-			},
-			"engines": {
-				"node": ">=20"
-			}
-		},
-		"node_modules/cssstyle/node_modules/@asamuzakjp/css-color": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
-			"integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@csstools/css-calc": "^3.0.0",
-				"@csstools/css-color-parser": "^4.0.1",
-				"@csstools/css-parser-algorithms": "^4.0.0",
-				"@csstools/css-tokenizer": "^4.0.0",
-				"lru-cache": "^11.2.5"
 			}
 		},
 		"node_modules/data-urls": {
@@ -2109,9 +2072,9 @@
 			}
 		},
 		"node_modules/diff": {
-			"version": "8.0.4",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-			"integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+			"integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
@@ -2147,9 +2110,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.376",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
-			"integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
+			"version": "1.5.395",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.395.tgz",
+			"integrity": "sha512-7zt9Aw+SrmxLWLN0zhaTWZQiCdryLVrYTq5R7iZakLvi2UQPYMMsROYV/2qVCzMeCiSXHwKOU+sZ4zOVVlrtKA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -2161,9 +2124,9 @@
 			"license": "MIT"
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.24.0",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.0.tgz",
-			"integrity": "sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==",
+			"version": "5.24.3",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
+			"integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2310,9 +2273,9 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+			"integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2359,13 +2322,14 @@
 			}
 		},
 		"node_modules/es-to-primitive": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.1.tgz",
-			"integrity": "sha512-CxN9N56HYfd2m/acc/NOFrZQsN9kU4eh+2kk6A707Kz1krH8tKmfrs5RnftB8WNX80T0NS7vSQsDOlg23diR2g==",
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+			"integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-abstract-get": "^1.0.0",
+				"es-define-property": "^1.0.1",
 				"es-errors": "^1.3.0",
 				"is-callable": "^1.2.7",
 				"is-date-object": "^1.1.0",
@@ -2512,9 +2476,9 @@
 			}
 		},
 		"node_modules/eslint-module-utils": {
-			"version": "2.13.0",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.13.0.tgz",
-			"integrity": "sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ==",
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz",
+			"integrity": "sha512-W2WCRZ9Dqntd+2u8jJcVMV2PKulc6RdLgUUoh/yQr3uB6lo/ZOeGx11sv60/8S4QFFKNslAlWhr9u0Ef7ZW6Ig==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2801,9 +2765,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
 			"dev": true,
 			"funding": [
 				{
@@ -2891,9 +2855,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+			"integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -3113,17 +3077,10 @@
 				"node": ">=10.13.0"
 			}
 		},
-		"node_modules/glob-to-regexp": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-			"dev": true,
-			"license": "BSD-2-Clause"
-		},
 		"node_modules/globals": {
-			"version": "17.6.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
-			"integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+			"version": "17.7.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+			"integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3342,30 +3299,6 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
-		"node_modules/http-proxy-agent": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.0",
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/http-proxy-agent/node_modules/agent-base": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 14"
-			}
-		},
 		"node_modules/https-proxy-agent": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -3397,9 +3330,9 @@
 			}
 		},
 		"node_modules/iconv-lite": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+			"version": "0.7.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+			"integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3990,147 +3923,31 @@
 			"license": "MIT"
 		},
 		"node_modules/jquery-test-runner": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/jquery-test-runner/-/jquery-test-runner-0.3.0.tgz",
-			"integrity": "sha512-p2hr+94JxQYN/csjhPny/go0vWgUHcWsvpJV5TwYx9iNqFmVw6BXmMy9AOsFxg3mVkLaU2o44mhRegMhJBkb2A==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/jquery-test-runner/-/jquery-test-runner-0.3.1.tgz",
+			"integrity": "sha512-xiQn60BkPk4/Hw+aVrwWK2SXrEcXYDGAt8433l0dprQ4hihw7k5jXC+OJlJhA+8NwFFurWnFuQIirVxEPcc7Kg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"browserstack-local": "^1.5.8",
+				"browserstack-local": "^1.5.13",
 				"chalk": "^5.6.2",
-				"commander": "^14.0.2",
-				"diff": "^8.0.2",
-				"exit-hook": "^5.0.1",
-				"jsdom": "^27.2.0",
-				"raw-body": "^3.0.1",
-				"selenium-webdriver": "^4.38.0",
-				"yaml": "^2.8.1"
+				"commander": "^15.0.0",
+				"diff": "^9.0.0",
+				"exit-hook": "^5.1.0",
+				"jsdom": "^29.1.1",
+				"raw-body": "^3.0.2",
+				"selenium-webdriver": "^4.45.0",
+				"yaml": "^2.9.0"
 			},
 			"bin": {
 				"jquery-test-runner": "bin/command.js",
 				"jtr": "bin/command.js"
 			}
 		},
-		"node_modules/jquery-test-runner/node_modules/@asamuzakjp/dom-selector": {
-			"version": "6.8.1",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
-			"integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@asamuzakjp/nwsapi": "^2.3.9",
-				"bidi-js": "^1.0.3",
-				"css-tree": "^3.1.0",
-				"is-potential-custom-element-name": "^1.0.1",
-				"lru-cache": "^11.2.6"
-			}
-		},
-		"node_modules/jquery-test-runner/node_modules/agent-base": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/jquery-test-runner/node_modules/data-urls": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
-			"integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"whatwg-mimetype": "^5.0.0",
-				"whatwg-url": "^15.1.0"
-			},
-			"engines": {
-				"node": ">=20"
-			}
-		},
-		"node_modules/jquery-test-runner/node_modules/https-proxy-agent": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.2",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/jquery-test-runner/node_modules/jsdom": {
-			"version": "27.4.0",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
-			"integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@acemir/cssom": "^0.9.28",
-				"@asamuzakjp/dom-selector": "^6.7.6",
-				"@exodus/bytes": "^1.6.0",
-				"cssstyle": "^5.3.4",
-				"data-urls": "^6.0.0",
-				"decimal.js": "^10.6.0",
-				"html-encoding-sniffer": "^6.0.0",
-				"http-proxy-agent": "^7.0.2",
-				"https-proxy-agent": "^7.0.6",
-				"is-potential-custom-element-name": "^1.0.1",
-				"parse5": "^8.0.0",
-				"saxes": "^6.0.0",
-				"symbol-tree": "^3.2.4",
-				"tough-cookie": "^6.0.0",
-				"w3c-xmlserializer": "^5.0.0",
-				"webidl-conversions": "^8.0.0",
-				"whatwg-mimetype": "^4.0.0",
-				"whatwg-url": "^15.1.0",
-				"ws": "^8.18.3",
-				"xml-name-validator": "^5.0.0"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-			},
-			"peerDependencies": {
-				"canvas": "^3.0.0"
-			},
-			"peerDependenciesMeta": {
-				"canvas": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/jquery-test-runner/node_modules/jsdom/node_modules/whatwg-mimetype": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-			"integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/jquery-test-runner/node_modules/whatwg-url": {
-			"version": "15.1.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
-			"integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"tr46": "^6.0.0",
-				"webidl-conversions": "^8.0.0"
-			},
-			"engines": {
-				"node": ">=20"
-			}
-		},
 		"node_modules/js-yaml": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -4325,9 +4142,9 @@
 			"license": "MIT"
 		},
 		"node_modules/lru-cache": {
-			"version": "11.5.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-			"integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
@@ -4401,6 +4218,67 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/minimizer-webpack-plugin": {
+			"version": "5.6.1",
+			"resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
+			"integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"jest-worker": "^27.4.5",
+				"schema-utils": "^4.3.0",
+				"terser": "^5.31.1"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			},
+			"peerDependencies": {
+				"webpack": "^5.1.0"
+			},
+			"peerDependenciesMeta": {
+				"@minify-html/node": {
+					"optional": true
+				},
+				"@swc/core": {
+					"optional": true
+				},
+				"@swc/css": {
+					"optional": true
+				},
+				"@swc/html": {
+					"optional": true
+				},
+				"clean-css": {
+					"optional": true
+				},
+				"cssnano": {
+					"optional": true
+				},
+				"csso": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"html-minifier-terser": {
+					"optional": true
+				},
+				"lightningcss": {
+					"optional": true
+				},
+				"postcss": {
+					"optional": true
+				},
+				"uglify-js": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4444,9 +4322,9 @@
 			}
 		},
 		"node_modules/node-exports-info": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
-			"integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.2.tgz",
+			"integrity": "sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4473,9 +4351,9 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.48",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
-			"integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
+			"version": "2.0.51",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+			"integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4634,13 +4512,14 @@
 			}
 		},
 		"node_modules/own-keys": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
-			"integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.2.tgz",
+			"integrity": "sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"get-intrinsic": "^1.2.6",
+				"call-bound": "^1.0.4",
+				"get-intrinsic": "^1.3.0",
 				"object-keys": "^1.1.1",
 				"safe-push-apply": "^1.0.0"
 			},
@@ -4778,9 +4657,9 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5238,9 +5117,9 @@
 			"license": "MIT"
 		},
 		"node_modules/selenium-webdriver": {
-			"version": "4.45.0",
-			"resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.45.0.tgz",
-			"integrity": "sha512-Cb2nqvJiwXVOtRTCYHX9D1FJR5+Ls7aL3Nev0t6n4CpXsQ//YGiiUmSCbvTDDeLtbV85SZ46qmLab4SIYKXWRw==",
+			"version": "4.46.0",
+			"resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.46.0.tgz",
+			"integrity": "sha512-UlTkgnx9y+bf3QxFsrgUyMqC2oy1Yf+qcOs7xIC/XfsUPv/ow7Sicx6SJ7AeOn2/Z+xF1M8SLqyn983wipI82w==",
 			"dev": true,
 			"funding": [
 				{
@@ -5727,9 +5606,9 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.48.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
-			"integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
+			"version": "5.49.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
+			"integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
@@ -5743,67 +5622,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/terser-webpack-plugin": {
-			"version": "5.6.1",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.1.tgz",
-			"integrity": "sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.25",
-				"jest-worker": "^27.4.5",
-				"schema-utils": "^4.3.0",
-				"terser": "^5.31.1"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
-			},
-			"peerDependencies": {
-				"webpack": "^5.1.0"
-			},
-			"peerDependenciesMeta": {
-				"@minify-html/node": {
-					"optional": true
-				},
-				"@swc/core": {
-					"optional": true
-				},
-				"@swc/css": {
-					"optional": true
-				},
-				"@swc/html": {
-					"optional": true
-				},
-				"clean-css": {
-					"optional": true
-				},
-				"cssnano": {
-					"optional": true
-				},
-				"csso": {
-					"optional": true
-				},
-				"esbuild": {
-					"optional": true
-				},
-				"html-minifier-terser": {
-					"optional": true
-				},
-				"lightningcss": {
-					"optional": true
-				},
-				"postcss": {
-					"optional": true
-				},
-				"uglify-js": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/terser/node_modules/commander": {
@@ -5832,22 +5650,22 @@
 			}
 		},
 		"node_modules/tldts": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.3.tgz",
-			"integrity": "sha512-A3BDQBeeukYPzB4QdQ1DtdlUmp4x2OCH8n5UVhEWbyANxNep8GavottKzd1xYKFJKjUgMyPT7EzOfnBO55s8Sg==",
+			"version": "7.4.9",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+			"integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tldts-core": "^7.4.3"
+				"tldts-core": "^7.4.9"
 			},
 			"bin": {
 				"tldts": "bin/cli.js"
 			}
 		},
 		"node_modules/tldts-core": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.3.tgz",
-			"integrity": "sha512-27ep5H9PzdBrNd5OFM/j3WCU8F3kPwM9D0BOaOf7uYfxMJfyr0K5Tjj69Gri+sZlh2WXd5buIm47NuPF29CDiw==",
+			"version": "7.4.9",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+			"integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -5872,9 +5690,9 @@
 			}
 		},
 		"node_modules/tough-cookie": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
-			"integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+			"integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -6178,9 +5996,9 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.107.2",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.2.tgz",
-			"integrity": "sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==",
+			"version": "5.108.4",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.108.4.tgz",
+			"integrity": "sha512-yur8LyJoeiWh47dErD+Ok7vlbmDsJ3UbbRPAoxbGJ54WpE2y5yVo5G/inUzujnYgw3tPmBRdn+G7PoxXaYC33w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6193,19 +6011,18 @@
 				"acorn-import-phases": "^1.0.3",
 				"browserslist": "^4.28.1",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.22.0",
+				"enhanced-resolve": "^5.22.2",
 				"es-module-lexer": "^2.1.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
-				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.2.11",
 				"loader-runner": "^4.3.2",
 				"mime-db": "^1.54.0",
+				"minimizer-webpack-plugin": "^5.6.1",
 				"neo-async": "^2.6.2",
 				"schema-utils": "^4.3.3",
 				"tapable": "^2.3.0",
-				"terser-webpack-plugin": "^5.5.0",
-				"watchpack": "^2.5.1",
+				"watchpack": "^2.5.2",
 				"webpack-sources": "^3.5.0"
 			},
 			"bin": {
@@ -6225,9 +6042,9 @@
 			}
 		},
 		"node_modules/webpack-sources": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.0.tgz",
-			"integrity": "sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==",
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.1.tgz",
+			"integrity": "sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -6453,9 +6270,9 @@
 			"license": "ISC"
 		},
 		"node_modules/ws": {
-			"version": "8.21.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+			"version": "8.21.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+			"integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -63,17 +63,17 @@
 		"eslint": "8.57.1",
 		"eslint-config-jquery": "3.0.2",
 		"eslint-plugin-import": "2.32.0",
-		"globals": "17.6.0",
+		"globals": "17.7.0",
 		"husky": "9.1.7",
 		"jquery": "4.0.0",
-		"jquery-test-runner": "0.3.0",
+		"jquery-test-runner": "0.3.1",
 		"jsdom": "29.1.1",
 		"native-promise-only": "0.8.1",
 		"qunit": "2.26.0",
 		"rollup": "4.62.2",
 		"sinon": "9.2.4",
 		"uglify-js": "3.19.3",
-		"webpack": "5.107.2",
+		"webpack": "5.108.4",
 		"yargs": "18.0.0"
 	},
 	"keywords": [
@@ -109,5 +109,8 @@
 			"Traversing",
 			"Wrap"
 		]
+	},
+	"allowScripts": {
+		"commitplease@3.2.0": true
 	}
 }


### PR DESCRIPTION
jsdom 30 dropped Node 20 (engines: ^22.22.2 || ^24.15.0 || >=26) and pulls undici 8, which requires Node >=22.19.0 and calls `webidl.util.markAsUncloneable` — absent in Node 20.